### PR TITLE
Show timezone in dashboard timestamps

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -446,7 +446,11 @@ function CycleStatus({
 }
 
 function formatTime(ms: number): string {
-  return new Date(ms).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  return new Date(ms).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  })
 }
 
 function formatRelative(targetMs: number): string {

--- a/web/src/components/PrTable.tsx
+++ b/web/src/components/PrTable.tsx
@@ -30,7 +30,11 @@ function formatFetchedAt(ms: number): string {
   const d = new Date(ms)
   const ageMs = Date.now() - ms
   if (ageMs < STALE_THRESHOLD_MS) {
-    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    return d.toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZoneName: 'short',
+    })
   }
   return d.toLocaleString([], {
     year: 'numeric',
@@ -38,6 +42,7 @@ function formatFetchedAt(ms: number): string {
     day: '2-digit',
     hour: '2-digit',
     minute: '2-digit',
+    timeZoneName: 'short',
   })
 }
 

--- a/web/src/components/RateLimitInfo.tsx
+++ b/web/src/components/RateLimitInfo.tsx
@@ -31,6 +31,7 @@ export function RateLimitInfo({ rl }: { rl: RL | null }) {
     const resetTime = new Date(rl.resetAt).toLocaleTimeString([], {
       hour: '2-digit',
       minute: '2-digit',
+      timeZoneName: 'short',
     })
     const mins = Math.max(0, Math.ceil((rl.resetAt - Date.now()) / 60_000))
     resetSuffix = ` · resets at ${resetTime} (in ${mins} min)`


### PR DESCRIPTION
## Summary

All three dashboard timestamp formatters now append the local timezone abbreviation:
- `formatTime` in `App.tsx` (header "Updated at", "next refresh at", "resumes at")
- `formatFetchedAt` in `PrTable.tsx` (per-repo fetch timestamps)
- `resetTime` in `RateLimitInfo.tsx` (rate-limit reset time)

So "06:13" becomes "06:13 CEST" / "06:13 GMT" depending on the viewer's locale. The SPA already renders in local time, so the original UTC-vs-CET confusion no longer applies — but the explicit timezone tag removes the lingering ambiguity that the issue described.

Fixes #2.

## Test plan

- [ ] Netlify preview shows timezone abbreviation in the header "Updated at"
- [ ] Per-repo "fetched at" timestamps show the abbreviation
- [ ] Rate-limit reset (anonymous mode only) shows the abbreviation
- [ ] In a non-Apple browser (Firefox/Chrome) the abbreviation renders as "CEST" / "GMT+2" depending on the Intl runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)
