### PR TITLE
Fix SPA artifact fallback to skip empty scheduled runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -262,14 +262,27 @@ jobs:
             gh run download "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" -n spa-dist -D public/dependabot-prs/
             echo "Used SPA built in this run"
           else
-            RUN_ID=$(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/publish.yml/runs" \
-                     -f branch=main -f status=success -f per_page=1 \
-                     --jq '.workflow_runs[0].id // empty')
+            # Walk recent successful main runs and pick the first one that
+            # still has a spa-dist artifact. Scheduled runs skip build-spa
+            # by design, so the *latest* successful run is usually empty;
+            # the most recent run that actually built the SPA can be many
+            # runs back.
+            RUN_ID=""
+            for ID in $(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/publish.yml/runs" \
+                         -f branch=main -f status=success -f per_page=20 \
+                         --jq '.workflow_runs[].id'); do
+              if gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${ID}/artifacts" \
+                 --jq '[.artifacts[].name] | index("spa-dist")' 2>/dev/null \
+                 | grep -qv '^null$'; then
+                RUN_ID="$ID"
+                break
+              fi
+            done
             if [ -n "$RUN_ID" ]; then
-              gh run download "$RUN_ID" -R "$GITHUB_REPOSITORY" -n spa-dist -D public/dependabot-prs/ 2>/dev/null \
-                || echo "::warning::Run #$RUN_ID has no spa-dist artifact"
+              gh run download "$RUN_ID" -R "$GITHUB_REPOSITORY" -n spa-dist -D public/dependabot-prs/
+              echo "Used SPA from prior run #$RUN_ID"
             else
-              echo "::warning::No prior publish.yml run on main — SPA missing"
+              echo "::warning::No publish.yml run on main within the last 20 has a spa-dist artifact — SPA missing"
             fi
           fi
 
@@ -280,12 +293,20 @@ jobs:
             gh run download "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" -n maven4-report -D public/
             echo "Used Maven 4 report scanned in this run"
           else
-            RUN_ID=$(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/publish.yml/runs" \
-                     -f branch=main -f status=success -f per_page=1 \
-                     --jq '.workflow_runs[0].id // empty')
+            RUN_ID=""
+            for ID in $(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/publish.yml/runs" \
+                         -f branch=main -f status=success -f per_page=20 \
+                         --jq '.workflow_runs[].id'); do
+              if gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${ID}/artifacts" \
+                 --jq '[.artifacts[].name] | index("maven4-report")' 2>/dev/null \
+                 | grep -qv '^null$'; then
+                RUN_ID="$ID"
+                break
+              fi
+            done
             if [ -n "$RUN_ID" ]; then
-              gh run download "$RUN_ID" -R "$GITHUB_REPOSITORY" -n maven4-report -D public/ 2>/dev/null \
-                || echo "::warning::Run #$RUN_ID has no maven4-report artifact"
+              gh run download "$RUN_ID" -R "$GITHUB_REPOSITORY" -n maven4-report -D public/
+              echo "Used Maven 4 report from prior run #$RUN_ID"
             else
               echo "::warning::No prior publish.yml run on main — Maven 4 report missing"
             fi
@@ -340,24 +361,34 @@ jobs:
             gh run download "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" -n spa-dist -D public/dependabot-prs/
             echo "Used SPA built in this run"
           else
+            # Walk recent successful publish.yml runs (current branch first,
+            # then main) and pick the first one that still has a spa-dist
+            # artifact. Scheduled runs on main skip build-spa by design.
             BRANCH="${{ github.head_ref || github.ref_name }}"
             RUN_ID=""
+            find_run_with_spa() {
+              local b="$1"
+              for ID in $(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/publish.yml/runs" \
+                           -f "branch=$b" -f status=success -f per_page=20 \
+                           --jq '.workflow_runs[].id'); do
+                if gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${ID}/artifacts" \
+                   --jq '[.artifacts[].name] | index("spa-dist")' 2>/dev/null \
+                   | grep -qv '^null$'; then
+                  echo "$ID"
+                  return 0
+                fi
+              done
+            }
             if [ "$BRANCH" != "main" ]; then
-              RUN_ID=$(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/publish.yml/runs" \
-                       -f "branch=$BRANCH" -f status=success -f per_page=1 \
-                       --jq '.workflow_runs[0].id // empty')
-              [ -n "$RUN_ID" ] && echo "Found publish.yml run on $BRANCH: #$RUN_ID"
+              RUN_ID="$(find_run_with_spa "$BRANCH")"
+              [ -n "$RUN_ID" ] && echo "Found publish.yml run with spa-dist on $BRANCH: #$RUN_ID"
             fi
-            if [ -z "$RUN_ID" ]; then
-              RUN_ID=$(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/publish.yml/runs" \
-                       -f branch=main -f status=success -f per_page=1 \
-                       --jq '.workflow_runs[0].id // empty')
-            fi
+            [ -z "$RUN_ID" ] && RUN_ID="$(find_run_with_spa main)"
             if [ -n "$RUN_ID" ]; then
-              gh run download "$RUN_ID" -R "$GITHUB_REPOSITORY" -n spa-dist -D public/dependabot-prs/ 2>/dev/null \
-                || echo "::warning::Run #$RUN_ID has no spa-dist artifact"
+              gh run download "$RUN_ID" -R "$GITHUB_REPOSITORY" -n spa-dist -D public/dependabot-prs/
+              echo "Used SPA from prior run #$RUN_ID"
             else
-              echo "::warning::No prior publish.yml run found — SPA missing from this preview"
+              echo "::warning::No publish.yml run within the last 20 has a spa-dist artifact — SPA missing from this preview"
             fi
           fi
 
@@ -370,22 +401,29 @@ jobs:
           else
             BRANCH="${{ github.head_ref || github.ref_name }}"
             RUN_ID=""
+            find_run_with_m4() {
+              local b="$1"
+              for ID in $(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/publish.yml/runs" \
+                           -f "branch=$b" -f status=success -f per_page=20 \
+                           --jq '.workflow_runs[].id'); do
+                if gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${ID}/artifacts" \
+                   --jq '[.artifacts[].name] | index("maven4-report")' 2>/dev/null \
+                   | grep -qv '^null$'; then
+                  echo "$ID"
+                  return 0
+                fi
+              done
+            }
             if [ "$BRANCH" != "main" ]; then
-              RUN_ID=$(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/publish.yml/runs" \
-                       -f "branch=$BRANCH" -f status=success -f per_page=1 \
-                       --jq '.workflow_runs[0].id // empty')
-              [ -n "$RUN_ID" ] && echo "Found publish.yml run on $BRANCH: #$RUN_ID"
+              RUN_ID="$(find_run_with_m4 "$BRANCH")"
+              [ -n "$RUN_ID" ] && echo "Found publish.yml run with maven4-report on $BRANCH: #$RUN_ID"
             fi
-            if [ -z "$RUN_ID" ]; then
-              RUN_ID=$(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/publish.yml/runs" \
-                       -f branch=main -f status=success -f per_page=1 \
-                       --jq '.workflow_runs[0].id // empty')
-            fi
+            [ -z "$RUN_ID" ] && RUN_ID="$(find_run_with_m4 main)"
             if [ -n "$RUN_ID" ]; then
-              gh run download "$RUN_ID" -R "$GITHUB_REPOSITORY" -n maven4-report -D public/ 2>/dev/null \
-                || echo "::warning::Run #$RUN_ID has no maven4-report artifact"
+              gh run download "$RUN_ID" -R "$GITHUB_REPOSITORY" -n maven4-report -D public/
+              echo "Used Maven 4 report from prior run #$RUN_ID"
             else
-              echo "::warning::No prior publish.yml run found — Maven 4 report missing from this preview"
+              echo "::warning::No publish.yml run within the last 20 has a maven4-report artifact — Maven 4 report missing from this preview"
             fi
           fi
 


### PR DESCRIPTION
## Summary

- **Bug:** [https://aschemaven.github.io/maven-simple-reports/dependabot-prs/](https://aschemaven.github.io/maven-simple-reports/dependabot-prs/) returns **404**. The site root and the Maven 4 report still resolve normally — only the SPA path is broken.
- **Root cause:** the publish-pages fallback grabs the *latest* successful `publish.yml` run via `per_page=1`, then tries to download `spa-dist` from it. Scheduled runs skip `build-spa` by design (they only refresh the Maven 4 scan), so `spa-dist` is absent from the latest several runs. The download fails silently (`2>/dev/null || echo "::warning::..."`), the publish job nevertheless succeeds, and the deploy ships an empty `public/dependabot-prs/`. The same pattern was duplicated in `publish-netlify`, so preview deploys would have suffered the same way.
- **Fix:** walk the last 20 successful runs (current branch first for previews, then `main`) and pick the first one whose artifact list actually contains the artifact we want. Once we've picked a run that advertises the artifact, the `gh run download` is allowed to fail loudly — it's a real problem at that point, not a known-acceptable miss.

### Diagnostic snapshot (state at the time of this PR)

| Run | Date | Trigger | build-spa | spa-dist artifact |
|---|---|---|---|---|
| 27462880993 | 2026-06-13 | schedule | skipped | ❌ not produced |
| 27409900418 | 2026-06-12 | schedule | skipped | ❌ |
| 27341654372 | 2026-06-11 | schedule | skipped | ❌ |
| 27269314379 | 2026-06-10 | schedule | skipped | ❌ |
| **27229955761** | **2026-06-09** | **push** | **success** | **✅ exists, not expired** |

The fix would have picked run `27229955761` and the live site would have stayed populated.

### Why the fix is also self-healing for the current state

This PR touches `.github/workflows/publish.yml`, which the workflow's own `context` job treats as a SPA-relevant change (`grep -qE '^(web/|\.github/workflows/publish\.yml$)'`). Merging this PR therefore *also* triggers a fresh SPA build, instantly restoring `public/dependabot-prs/` on the next deploy. No follow-up no-op push needed.

## Test plan

- [ ] Watch the PR's own Netlify preview deploy — the new walk-the-runs logic should kick in for `publish-netlify` and produce a working `/dependabot-prs/` page in the preview.
- [ ] Merge and watch the resulting `publish-pages` run on main: build-spa should now run (because publish.yml changed) and the deploy should populate `public/dependabot-prs/` directly without exercising the fallback.
- [ ] After the next scheduled run (≈ 06:00 UTC daily), verify [https://aschemaven.github.io/maven-simple-reports/dependabot-prs/](https://aschemaven.github.io/maven-simple-reports/dependabot-prs/) still returns 200 — this is the real regression test, since the scheduled run is what previously broke the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
