### PR TITLE
Add repo link footer to all report pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -326,7 +326,7 @@ jobs:
           for adoc_file in public/*.adoc; do
             html_file="${adoc_file%.adoc}.html"
             echo "  Converting $(basename "$adoc_file")..."
-            asciidoctor -o "$html_file" "$adoc_file"
+            asciidoctor -a docinfo=shared-footer -o "$html_file" "$adoc_file"
           done
 
       - name: Upload Pages artifact
@@ -441,7 +441,7 @@ jobs:
           for adoc_file in public/*.adoc; do
             html_file="${adoc_file%.adoc}.html"
             echo "  Converting $(basename "$adoc_file")..."
-            asciidoctor -o "$html_file" "$adoc_file"
+            asciidoctor -a docinfo=shared-footer -o "$html_file" "$adoc_file"
           done
 
       - name: Set Netlify alias

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 public/*.adoc
 !public/index.adoc
 public/*.html
+!public/docinfo-footer.html
 public/*.csv
 public/dependabot-prs/
 cache/

--- a/public/docinfo-footer.html
+++ b/public/docinfo-footer.html
@@ -1,4 +1,4 @@
 <div id="repo-link" style="text-align: center; padding: 1em 0; font-size: 0.85em; color: #777;">
   Source &amp; issues:
-  <a href="https://github.com/aschemaven/maven-simple-reports" target="_blank" rel="noopener">github.com/aschemaven/maven-simple-reports</a>
+  <a href="https://github.com/aschemaven/maven-simple-reports" target="_blank" rel="noopener noreferrer">github.com/aschemaven/maven-simple-reports</a>
 </div>

--- a/public/docinfo-footer.html
+++ b/public/docinfo-footer.html
@@ -1,0 +1,4 @@
+<div id="repo-link" style="text-align: center; padding: 1em 0; font-size: 0.85em; color: #777;">
+  Source &amp; issues:
+  <a href="https://github.com/aschemaven/maven-simple-reports" target="_blank" rel="noopener">github.com/aschemaven/maven-simple-reports</a>
+</div>

--- a/public/docinfo-footer.html
+++ b/public/docinfo-footer.html
@@ -1,4 +1,4 @@
 <div id="repo-link" style="text-align: center; padding: 1em 0; font-size: 0.85em; color: #777;">
-  Source &amp; issues:
-  <a href="https://github.com/aschemaven/maven-simple-reports" target="_blank" rel="noopener noreferrer">github.com/aschemaven/maven-simple-reports</a>
+  Contribute on GitHub:
+  <a href="https://github.com/aschemaven/maven-simple-reports" target="_blank" rel="noopener noreferrer">aschemaven/maven-simple-reports</a>
 </div>

--- a/scripts/generate_report.sh
+++ b/scripts/generate_report.sh
@@ -41,7 +41,7 @@ shopt -s nullglob
 for adoc_file in "${REPO_ROOT}/public"/*.adoc; do
     html_file="${adoc_file%.adoc}.html"
     echo "  Converting $(basename "$adoc_file")..."
-    asciidoctor -o "$html_file" "$adoc_file"
+    asciidoctor -a docinfo=shared-footer -o "$html_file" "$adoc_file"
 done
 
 echo "Report generated successfully in ${REPO_ROOT}/public/"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -400,6 +400,16 @@ export function App() {
         <p>
           Static SPA · GitHub REST API · ETag-cached, serial polling. The unauthenticated 60 req/h limit is shared per IP.
         </p>
+        <p>
+          Source &amp; issues:{' '}
+          <a
+            href="https://github.com/aschemaven/maven-simple-reports"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            github.com/aschemaven/maven-simple-reports
+          </a>
+        </p>
       </footer>
     </div>
   )

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -401,13 +401,13 @@ export function App() {
           Static SPA · GitHub REST API · ETag-cached, serial polling. The unauthenticated 60 req/h limit is shared per IP.
         </p>
         <p>
-          Source &amp; issues:{' '}
+          Contribute on GitHub:{' '}
           <a
             href="https://github.com/aschemaven/maven-simple-reports"
             target="_blank"
             rel="noopener noreferrer"
           >
-            github.com/aschemaven/maven-simple-reports
+            aschemaven/maven-simple-reports
           </a>
         </p>
       </footer>


### PR DESCRIPTION
## Summary

- Adds a small **"Source & issues" link** to the bottom of every published page (the static AsciiDoc reports *and* the SPA), pointing at this repository.
- For the AsciiDoc pages: uses asciidoctor's `shared-footer` docinfo mechanism. One file (`public/docinfo-footer.html`) is injected just before `</body>` on every render, so individual generators (incl. the daily Maven 4 report) don't need to know about it. Both render call sites (`scripts/generate_report.sh` for local builds and `.github/workflows/publish.yml` for Pages + Netlify) are updated.
- For the SPA: adds a second `<p>` to the existing footer in `App.tsx` with the same link.

The new file is the first tracked artifact under `public/` besides `index.adoc`, so `.gitignore` gets a matching `!public/docinfo-footer.html` exception.

## Preview

What the footer looks like in the rendered HTML:

```html
<div id="repo-link" style="text-align: center; padding: 1em 0; font-size: 0.85em; color: #777;">
  Source &amp; issues:
  <a href="https://github.com/aschemaven/maven-simple-reports" target="_blank" rel="noopener">github.com/aschemaven/maven-simple-reports</a>
</div>
```

And in the SPA:

```
Static SPA · GitHub REST API · ETag-cached, serial polling. …
Source & issues: github.com/aschemaven/maven-simple-reports
```

## Test plan

- [ ] Pull the PR's Netlify preview and confirm the footer appears on:
  - `/` (index, rendered from `public/index.adoc`)
  - `/maven4-adoption.html` (the daily report)
  - `/dependabot-prs/` (the SPA — bottom of the page)
- [ ] Click the link in each and confirm it opens the repo in a new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
