### PR TITLE
Registry-based Maven 4 adoption pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -278,12 +278,11 @@ jobs:
 
   publish-pages:
     runs-on: ubuntu-latest
-    needs: [context, build-spa, scan-maven4]
+    needs: [context, build-spa]
     if: |
       always()
       && needs.context.outputs.deploy-target == 'pages'
       && needs.build-spa.result == 'success'
-      && (needs.scan-maven4.result == 'success' || needs.scan-maven4.result == 'skipped')
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
@@ -350,12 +349,11 @@ jobs:
 
   publish-netlify:
     runs-on: ubuntu-latest
-    needs: [context, build-spa, scan-maven4]
+    needs: [context, build-spa]
     if: |
       always()
       && needs.context.outputs.deploy-target == 'netlify'
       && needs.build-spa.result == 'success'
-      && (needs.scan-maven4.result == 'success' || needs.scan-maven4.result == 'skipped')
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,38 +1,29 @@
 name: Publish
 
-# Single pipeline that handles every build/deploy path:
+# Site build/deploy pipeline:
 #
-#   trigger             | SPA build          | Maven 4 scan  | deploy target
-#   ----                | ---------          | ------------- | -------------
-#   push main           | cached (iff web/)  | iff scripts/  | GitHub Pages
-#   push branch         | cached (iff web/)  | iff scripts/  | Netlify preview
-#   pull_request        | cached (iff web/)  | iff scripts/  | Netlify preview
-#   schedule (06:00)    | cached             | yes           | GitHub Pages
-#   workflow_dispatch   | cached             | yes           | Pages (main) / Netlify (branch)
+#   trigger             | SPA build          | deploy target
+#   ----                | ---------          | -------------
+#   push main           | cached (iff web/)  | GitHub Pages
+#   push branch         | cached (iff web/)  | Netlify preview
+#   pull_request        | cached (iff web/)  | Netlify preview
+#   workflow_dispatch   | cached             | Pages (main) / Netlify (branch)
 #
 # The build-spa job always runs but restores web/dist from the Actions
 # cache (key = hash of web/**); it only rebuilds on a cache miss (web/
-# changed, or the cache was evicted). So every deploy gets a ready SPA
-# without depending on any artifact retention window. The Maven 4 report
-# is regenerated on schedule/dispatch and otherwise falls back to the
-# latest successful run's artifact (renewed daily, so it never expires).
+# changed, or the cache was evicted). The Maven 4 adoption report is
+# rendered from the registry on the data branch, which the Maven 4
+# Registry workflow (registry.yml) keeps fresh — that workflow dispatches
+# this one after each data change, so no cron is needed here.
 
 on:
   push:
     branches: ['**']
   pull_request:
-  schedule:
-    - cron: '0 6 * * *'
   workflow_dispatch:
-    inputs:
-      no_cache:
-        description: 'Disable API response cache (fetch fresh data from GitHub)'
-        required: false
-        default: false
-        type: boolean
 
 permissions:
-  contents: write       # push history to data branch
+  contents: read
   pages: write          # deploy to Pages
   id-token: write       # OIDC for actions/deploy-pages
   pull-requests: write  # Netlify bot PR comment
@@ -52,15 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       deploy-target: ${{ steps.ctx.outputs.deploy-target }}
-      need-maven4-scan: ${{ steps.ctx.outputs.need-maven4-scan }}
       is-main: ${{ steps.ctx.outputs.is-main }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Resolve deploy target and rebuild needs
+      - name: Resolve deploy target
         id: ctx
         run: |
           set -e
@@ -73,9 +58,6 @@ jobs:
           # Decide where the run deploys.
           TARGET=none
           case "$EVENT" in
-            schedule)
-              TARGET=pages
-              ;;
             push|workflow_dispatch)
               if [ "$IS_MAIN" = "true" ]; then
                 TARGET=pages
@@ -88,40 +70,9 @@ jobs:
               ;;
           esac
 
-          # Decide whether to rescan the Maven 4 report. Schedule/dispatch
-          # always rescan (the whole point of those triggers); a push
-          # rescans only when the scanner or its config changed. The SPA is
-          # not decided here — build-spa always runs and lets the Actions
-          # cache decide between restore and rebuild.
-          NEED_MAVEN4=false
-          if [ "$EVENT" = "schedule" ] || [ "$EVENT" = "workflow_dispatch" ]; then
-            NEED_MAVEN4=true
-          fi
-
-          if [ "$EVENT" = "pull_request" ] || [ "$EVENT" = "push" ]; then
-            if [ "$EVENT" = "pull_request" ]; then
-              BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
-              git fetch origin "$BASE_BRANCH" --depth=1 || true
-              BASE_REF="origin/$BASE_BRANCH"
-            elif [ "$IS_MAIN" = "true" ]; then
-              BASE_REF="HEAD~1"
-            else
-              git fetch origin main --depth=1 || true
-              BASE_REF="origin/main"
-            fi
-            CHANGED=$(git diff --name-only "$BASE_REF...HEAD" 2>/dev/null || true)
-            echo "Changed files vs $BASE_REF:"
-            echo "$CHANGED"
-
-            if echo "$CHANGED" | grep -qE '^(scripts/(export_maven4_adoption|migrate_history_to_federated)\.py|\.gh-configuration\.yaml)$'; then
-              NEED_MAVEN4=true
-            fi
-          fi
-
           echo "is-main=$IS_MAIN" >> "$GITHUB_OUTPUT"
           echo "deploy-target=$TARGET" >> "$GITHUB_OUTPUT"
-          echo "need-maven4-scan=$NEED_MAVEN4" >> "$GITHUB_OUTPUT"
-          echo "Resolved: target=$TARGET need-maven4=$NEED_MAVEN4 is-main=$IS_MAIN"
+          echo "Resolved: target=$TARGET is-main=$IS_MAIN"
 
   build-spa:
     runs-on: ubuntu-latest
@@ -164,115 +115,6 @@ jobs:
         with:
           name: spa-dist
           path: web/dist/
-          retention-days: 90
-          if-no-files-found: error
-
-  scan-maven4:
-    runs-on: ubuntu-latest
-    needs: context
-    if: needs.context.outputs.need-maven4-scan == 'true'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      # Restore adoption data from the data branch:
-      #   - per-repo snapshot for every trigger (previews use it as a fast
-      #     read-only path; only main pushes write it back)
-      #   - time series history only on main paths (previews would otherwise
-      #     pollute the daily cadence)
-      # First production run will see no branch yet and start from scratch.
-      - name: Restore adoption data from data branch
-        run: |
-          mkdir -p data
-          if git ls-remote --exit-code --heads origin data >/dev/null 2>&1; then
-            git fetch origin data --depth=1
-            git show FETCH_HEAD:maven4-repos-snapshot.json > data/maven4-repos-snapshot.json 2>/dev/null \
-              && echo "Restored snapshot ($(wc -c < data/maven4-repos-snapshot.json) bytes)" \
-              || echo "No prior snapshot on data branch yet"
-            if [ "${{ needs.context.outputs.is-main }}" = "true" ]; then
-              git show FETCH_HEAD:maven4-adoption-history.json > data/maven4-adoption-history.json 2>/dev/null \
-                && echo "Restored history ($(wc -c < data/maven4-adoption-history.json) bytes)" \
-                || echo "No prior history on data branch yet"
-            fi
-          else
-            echo "data branch does not exist yet — starting from scratch"
-          fi
-
-      - name: Cache GitHub API responses
-        if: ${{ inputs.no_cache != true }}
-        uses: actions/cache@v4
-        with:
-          path: cache/gh_api_cache.json
-          key: maven4-gh-cache-${{ github.run_id }}
-          restore-keys: |
-            maven4-gh-cache-
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-
-      - name: Generate Maven 4 adoption report
-        run: |
-          mkdir -p cache data public
-          FLAGS=""
-          if [ "${{ inputs.no_cache }}" = "true" ]; then
-            FLAGS="$FLAGS --no-cache"
-          fi
-          # Fast-path via the per-repo snapshot for every trigger EXCEPT
-          # the daily scheduled scan (which is the canonical full refresh)
-          # and explicit no_cache dispatches. Previews don't write the
-          # snapshot back (so they don't steal it from main).
-          if [ "${{ github.event_name }}" != "schedule" ] && [ "${{ inputs.no_cache }}" != "true" ]; then
-            FLAGS="$FLAGS --use-snapshot"
-          fi
-          if [ "${{ needs.context.outputs.is-main }}" != "true" ]; then
-            FLAGS="$FLAGS --no-history --no-snapshot-write"
-          fi
-          scripts/export_maven4_adoption.py \
-            --format asciidoc \
-            --output public/maven4-adoption.adoc \
-            $FLAGS
-
-      - name: Push updated adoption data to data branch
-        if: needs.context.outputs.is-main == 'true'
-        run: |
-          files=()
-          [ -f data/maven4-adoption-history.json ] && files+=(maven4-adoption-history.json)
-          [ -f data/maven4-repos-snapshot.json ]  && files+=(maven4-repos-snapshot.json)
-          if [ ${#files[@]} -eq 0 ]; then
-            echo "No data files to push"
-            exit 0
-          fi
-          WORK=$(mktemp -d)
-          cd "$WORK"
-          REPO_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          if git clone --depth=1 --branch data --single-branch "$REPO_URL" . 2>/dev/null; then
-            echo "Cloned existing data branch"
-          else
-            echo "data branch does not exist; initializing orphan"
-            git init -q
-            git remote add origin "$REPO_URL"
-            git checkout --orphan data
-          fi
-          for f in "${files[@]}"; do
-            cp "$GITHUB_WORKSPACE/data/$f" .
-            git add "$f"
-          done
-          if git diff --staged --quiet; then
-            echo "No data changes — nothing to commit"
-            exit 0
-          fi
-          git -c user.name='github-actions[bot]' \
-              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
-              commit -m "Update Maven 4 adoption data ($(date -u +%Y-%m-%d))"
-          git push origin HEAD:data
-
-      - name: Upload Maven 4 report artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: maven4-report
-          path: public/maven4-adoption.adoc
           retention-days: 90
           if-no-files-found: error
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,7 +113,7 @@ jobs:
             echo "Changed files vs $BASE_REF:"
             echo "$CHANGED"
 
-            if echo "$CHANGED" | grep -qE '^(scripts/(export_maven4_adoption|migrate_history_to_federated)\.py|\.gh-configuration\.yaml|\.github/workflows/publish\.yml)$'; then
+            if echo "$CHANGED" | grep -qE '^(scripts/(export_maven4_adoption|migrate_history_to_federated)\.py|\.gh-configuration\.yaml)$'; then
               NEED_MAVEN4=true
             fi
           fi
@@ -299,31 +299,27 @@ jobs:
           gh run download "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" -n spa-dist -D public/dependabot-prs/
           echo "Deployed SPA from this run's build-spa job"
 
-      - name: Get Maven 4 report artifact (this run, then fall back)
+      - name: Restore Maven 4 registry from data branch
         run: |
-          mkdir -p public
-          if [ "${{ needs.scan-maven4.result }}" = "success" ]; then
-            gh run download "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" -n maven4-report -D public/
-            echo "Used Maven 4 report scanned in this run"
+          mkdir -p public data
+          if git ls-remote --exit-code --heads origin data >/dev/null 2>&1; then
+            git fetch origin data --depth=1
+            git show FETCH_HEAD:maven4-registry.json > data/maven4-registry.json 2>/dev/null \
+              && echo "Restored registry ($(wc -c < data/maven4-registry.json) bytes)" \
+              || echo "::warning::No maven4-registry.json on data branch yet"
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Render Maven 4 adoption report (HTML, from registry)
+        run: |
+          if [ -f data/maven4-registry.json ]; then
+            python scripts/render_registry_report.py data/maven4-registry.json public/maven4-adoption.html
           else
-            DOWNLOADED=""
-            for ID in $(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/publish.yml/runs" \
-                         -f branch=main -f status=success -f per_page=20 \
-                         --jq '.workflow_runs[].id'); do
-              if gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${ID}/artifacts" \
-                 --jq '.artifacts[] | select(.expired==false) | .name' 2>/dev/null \
-                 | grep -qx 'maven4-report'; then
-                if gh run download "$ID" -R "$GITHUB_REPOSITORY" -n maven4-report -D public/ 2>/dev/null; then
-                  echo "Used Maven 4 report from prior run #$ID"
-                  DOWNLOADED=1
-                  break
-                fi
-                echo "Run #$ID listed maven4-report but download failed; trying next"
-              fi
-            done
-            if [ -z "$DOWNLOADED" ]; then
-              echo "::warning::No publish.yml run on main within the last 20 has a downloadable maven4-report artifact"
-            fi
+            echo "::warning::No registry on data branch — Maven 4 report missing"
           fi
 
       - name: Set up Ruby
@@ -373,38 +369,27 @@ jobs:
           gh run download "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" -n spa-dist -D public/dependabot-prs/
           echo "Deployed SPA from this run's build-spa job"
 
-      - name: Get Maven 4 report artifact (this run, then fall back)
+      - name: Restore Maven 4 registry from data branch
         run: |
-          mkdir -p public
-          if [ "${{ needs.scan-maven4.result }}" = "success" ]; then
-            gh run download "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" -n maven4-report -D public/
-            echo "Used Maven 4 report scanned in this run"
+          mkdir -p public data
+          if git ls-remote --exit-code --heads origin data >/dev/null 2>&1; then
+            git fetch origin data --depth=1
+            git show FETCH_HEAD:maven4-registry.json > data/maven4-registry.json 2>/dev/null \
+              && echo "Restored registry ($(wc -c < data/maven4-registry.json) bytes)" \
+              || echo "::warning::No maven4-registry.json on data branch yet"
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Render Maven 4 adoption report (HTML, from registry)
+        run: |
+          if [ -f data/maven4-registry.json ]; then
+            python scripts/render_registry_report.py data/maven4-registry.json public/maven4-adoption.html
           else
-            BRANCH="${{ github.head_ref || github.ref_name }}"
-            try_download_m4() {
-              local b="$1"
-              for ID in $(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/publish.yml/runs" \
-                           -f "branch=$b" -f status=success -f per_page=20 \
-                           --jq '.workflow_runs[].id'); do
-                if gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${ID}/artifacts" \
-                   --jq '.artifacts[] | select(.expired==false) | .name' 2>/dev/null \
-                   | grep -qx 'maven4-report'; then
-                  if gh run download "$ID" -R "$GITHUB_REPOSITORY" -n maven4-report -D public/ 2>/dev/null; then
-                    echo "Used Maven 4 report from prior run #$ID (branch $b)"
-                    return 0
-                  fi
-                  echo "Run #$ID listed maven4-report but download failed; trying next"
-                fi
-              done
-              return 1
-            }
-            if [ "$BRANCH" != "main" ] && try_download_m4 "$BRANCH"; then
-              :
-            elif try_download_m4 main; then
-              :
-            else
-              echo "::warning::No publish.yml run within the last 20 has a downloadable maven4-report artifact — Maven 4 report missing from this preview"
-            fi
+            echo "::warning::No registry on data branch — Maven 4 report missing from this preview"
           fi
 
       - name: Set up Ruby

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -1,0 +1,161 @@
+name: Maven 4 Registry
+
+# Two-job registry pipeline that replaces the old daily search sampling:
+#
+#   trigger                     | mode        | discovery                  | re-examination
+#   ----                        | ----        | ---------                  | --------------
+#   cron '13 */2 * * *' (Job B) | incremental | sort=indexed, early-stop   | stalest slice
+#   cron '43 5 * * *'   (Job A) | full        | full sweep + reconciliation| everything
+#   workflow_dispatch           | choice      | per input                  | per input
+#
+# The registry (maven4-registry.json on the data branch) is the durable
+# list of every repo ever seen with a Maven 4 signal; counting happens by
+# re-examining registry entries via the core API (5000/h with a PAT,
+# 1000/h with GITHUB_TOKEN) instead of the rate-limit-flaky code search.
+# The search only discovers NEW candidates, so a throttled search means
+# "no news today", never a collapsed count.
+#
+# Optional secret REGISTRY_TOKEN (classic PAT, public_repo scope) lifts
+# the API budget from 1000/h to 5000/h; without it the scripts' rate-limit
+# guard sleeps across window resets, the jobs just take longer.
+
+on:
+  schedule:
+    - cron: '13 */2 * * *'   # Job B: incremental
+    - cron: '43 5 * * *'     # Job A: full sweep + reconciliation
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Discovery + re-examination mode'
+        required: false
+        default: 'incremental'
+        type: choice
+        options: [incremental, full]
+
+permissions:
+  contents: write   # push registry/history to the data branch
+  actions: write    # dispatch the Publish workflow after data changes
+
+# Job A must not run concurrently with Job B (both rewrite the registry on
+# the data branch): same group, queue instead of cancel.
+concurrency:
+  group: maven4-registry
+  cancel-in-progress: false
+
+env:
+  GH_TOKEN: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
+
+jobs:
+  registry:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve mode
+        id: mode
+        run: |
+          MODE="incremental"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            MODE="${{ inputs.mode }}"
+          elif [ "${{ github.event.schedule }}" = "43 5 * * *" ]; then
+            MODE="full"
+          fi
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+          echo "Resolved mode: $MODE"
+
+      - name: Restore registry and history from data branch
+        run: |
+          mkdir -p data
+          if git ls-remote --exit-code --heads origin data >/dev/null 2>&1; then
+            git fetch origin data --depth=1
+            git show FETCH_HEAD:maven4-registry.json > data/maven4-registry.json 2>/dev/null \
+              && echo "Restored registry ($(wc -c < data/maven4-registry.json) bytes)" \
+              || { echo "No registry on data branch yet"; rm -f data/maven4-registry.json; }
+            git show FETCH_HEAD:maven4-adoption-history.json > data/maven4-adoption-history.json 2>/dev/null \
+              && echo "Restored history ($(wc -c < data/maven4-adoption-history.json) bytes)" \
+              || { echo "No history on data branch yet"; rm -f data/maven4-adoption-history.json; }
+          else
+            echo "data branch does not exist yet — starting from scratch"
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Discover (${{ steps.mode.outputs.mode }})
+        run: |
+          python scripts/registry_discover.py data/maven4-registry.json \
+            --mode "${{ steps.mode.outputs.mode }}"
+
+      - name: Re-examine registry entries
+        run: |
+          if [ "${{ steps.mode.outputs.mode }}" = "full" ]; then
+            python scripts/registry_reexamine.py data/maven4-registry.json
+          else
+            # stalest slice only: keeps the 2-hourly run inside the API
+            # budget; every entry still gets re-examined a few times a day
+            python scripts/registry_reexamine.py data/maven4-registry.json \
+              --max-checks 100
+          fi
+
+      - name: Refresh build status
+        run: |
+          if [ "${{ steps.mode.outputs.mode }}" = "full" ]; then
+            python scripts/registry_build_status.py data/maven4-registry.json
+          else
+            python scripts/registry_build_status.py data/maven4-registry.json \
+              --max-checks 60
+          fi
+
+      - name: Append adoption history point
+        run: |
+          python scripts/registry_history.py \
+            data/maven4-registry.json data/maven4-adoption-history.json
+
+      - name: Push registry and history to data branch
+        id: push-data
+        run: |
+          WORK=$(mktemp -d)
+          cd "$WORK"
+          REPO_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          for attempt in 1 2 3; do
+            rm -rf "$WORK"/* "$WORK"/.git 2>/dev/null || true
+            if git clone --depth=1 --branch data --single-branch "$REPO_URL" . 2>/dev/null; then
+              echo "Cloned data branch (attempt $attempt)"
+            else
+              git init -q
+              git remote add origin "$REPO_URL"
+              git checkout -q --orphan data
+            fi
+            cp "$GITHUB_WORKSPACE/data/maven4-registry.json" .
+            cp "$GITHUB_WORKSPACE/data/maven4-adoption-history.json" .
+            git add maven4-registry.json maven4-adoption-history.json
+            if git diff --staged --quiet; then
+              echo "No data changes — nothing to commit"
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            git -c user.name='github-actions[bot]' \
+                -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+                commit -q -m "Update Maven 4 registry (${{ steps.mode.outputs.mode }}, $(date -u +%Y-%m-%dT%H:%MZ))"
+            if git push origin HEAD:data; then
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Push rejected (concurrent update?), retrying..."
+          done
+          echo "::error::Could not push data branch after 3 attempts"
+          exit 1
+
+      - name: Refresh published report
+        if: steps.push-data.outputs.changed == 'true'
+        run: |
+          # Re-render GitHub Pages from the fresh registry. workflow_dispatch
+          # events are exempt from GITHUB_TOKEN's no-recursion rule.
+          gh workflow run publish.yml --ref main \
+            && echo "Dispatched Publish on main" \
+            || echo "::warning::Could not dispatch Publish (report refreshes on next push/dispatch)"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/export_maven4_adoption.py
+++ b/scripts/export_maven4_adoption.py
@@ -230,31 +230,45 @@ def _gh_api_call_raw(endpoint, params=None, method='GET'):
         for key, value in params.items():
             cmd.extend(['-f', f'{key}={value}'])
 
-    try:
-        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-        return json.loads(result.stdout)
-    except subprocess.CalledProcessError as e:
-        stderr = e.stderr or ''
-        if '403' in stderr or '429' in stderr or 'rate limit' in stderr.lower():
-            print(f"  Rate limited on {endpoint}, waiting 60s...", file=sys.stderr)
-            time.sleep(60)
-            # Retry once
-            try:
-                result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-                return json.loads(result.stdout)
-            except subprocess.CalledProcessError:
+    # Code search shares a stricter secondary rate limit than the core API.
+    # A single 60s retry was not enough: the wrapper and GH-Action searches
+    # run after the POM search has drained the budget and were left empty on
+    # essentially every run, collapsing the 'signals'/'maven_runtime' columns.
+    # Retry rate-limit failures several times with escalating backoff.
+    max_rate_limit_retries = 3
+    attempt = 0
+    while True:
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            return json.loads(result.stdout)
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr or ''
+            is_rate_limit = ('403' in stderr or '429' in stderr
+                             or 'rate limit' in stderr.lower())
+            if is_rate_limit and attempt < max_rate_limit_retries:
+                attempt += 1
+                wait = 30 + 60 * attempt  # 90s, 150s, 210s
+                print(f"  Rate limited on {endpoint}, waiting {wait}s "
+                      f"(attempt {attempt}/{max_rate_limit_retries})...",
+                      file=sys.stderr)
+                time.sleep(wait)
+                continue
+            if is_rate_limit:
+                print(f"  Still rate limited on {endpoint} after "
+                      f"{max_rate_limit_retries} retries; giving up.",
+                      file=sys.stderr)
                 return None
-        if '404' in stderr:
-            # Not found — expected for file existence checks
+            if '404' in stderr:
+                # Not found — expected for file existence checks
+                return None
+            if '422' in stderr:
+                # Validation error (e.g., search query issues)
+                print(f"  API validation error on {endpoint}: {stderr.strip()}", file=sys.stderr)
+                return None
+            print(f"  API error on {endpoint}: {stderr.strip()}", file=sys.stderr)
             return None
-        if '422' in stderr:
-            # Validation error (e.g., search query issues)
-            print(f"  API validation error on {endpoint}: {stderr.strip()}", file=sys.stderr)
+        except json.JSONDecodeError:
             return None
-        print(f"  API error on {endpoint}: {stderr.strip()}", file=sys.stderr)
-        return None
-    except json.JSONDecodeError:
-        return None
 
 
 def gh_api_call(endpoint, params=None, method='GET'):

--- a/scripts/export_maven4_adoption.py
+++ b/scripts/export_maven4_adoption.py
@@ -50,7 +50,11 @@ HISTORY_PATH = Path(__file__).resolve().parent.parent / 'data' / 'maven4-adoptio
 # hasn't changed since the snapshot was taken. Lives alongside the history
 # file on the data branch; see scan-maven4 in publish.yml for restore/push.
 SNAPSHOT_PATH = Path(__file__).resolve().parent.parent / 'data' / 'maven4-repos-snapshot.json'
-SNAPSHOT_SCHEMA_VERSION = 1
+# Bump whenever enrichment semantics change so cached entries are not reused
+# with stale values. v2: pom_model now probes the real root pom (was a
+# constant '4.1.0' for POM-signal repos) and maven_runtime uses the
+# discovered wrapper path (was empty for non-root wrappers).
+SNAPSHOT_SCHEMA_VERSION = 2
 
 # Forge attribution for the federated history schema. Today only the GitHub
 # runner writes here, so each snapshot carries by_forge.github plus mirrored
@@ -413,11 +417,15 @@ def extract_maven4_version(content):
     return None
 
 
-def extract_version_from_wrapper(owner, repo):
-    """Fetch maven-wrapper.properties and extract Maven 4 version."""
-    content = fetch_file_content(
-        owner, repo, '.mvn/wrapper/maven-wrapper.properties'
-    )
+def extract_version_from_wrapper(owner, repo,
+                                 file_path='.mvn/wrapper/maven-wrapper.properties'):
+    """Fetch maven-wrapper.properties and extract Maven 4 version.
+
+    file_path is the wrapper path discovered by the code search; a repo
+    can carry its wrapper below the root (e.g. sub-module/.mvn/...), so
+    trusting a hardcoded root path left maven_runtime empty for them.
+    """
+    content = fetch_file_content(owner, repo, file_path)
     if not content:
         return None
     return extract_maven4_version(content)
@@ -441,16 +449,18 @@ def detect_pom_model(owner, repo, files):
     pom.xml could be located or parsed.
 
     Strategy:
-    - If the repo already has a POM 4.1.0 signal, return '4.1.0' (the
-      code-search query that produced the signal targets that exact
-      namespace; no file fetch needed).
-    - Otherwise probe the project root pom.xml. For wrapper-using repos
-      the root is the directory containing .mvn/. As a fallback, try
-      the repository root.
-    """
-    if 'pom' in files:
-        return '4.1.0'
+    - Always probe the actual project root pom.xml. For wrapper-using
+      repos the root is the directory containing .mvn/; otherwise the
+      repository root.
+    - Fall back to '4.1.0' only when the root pom cannot be read but the
+      repo carries the POM 4.1.0 signal (some (sub)module declared it).
 
+    We deliberately do NOT short-circuit to '4.1.0' just because the POM
+    signal fired: a repo is surfaced by the 4.1.0 code search whenever
+    *any* (sub)module declares that namespace, while its root pom may
+    still be on 4.0.0. Trusting the signal collapsed this column to a
+    constant '4.1.0' for every POM-signal repo.
+    """
     candidates = []
     wrapper = files.get('wrapper', '')
     suffix = '.mvn/wrapper/maven-wrapper.properties'
@@ -467,6 +477,10 @@ def detect_pom_model(owner, repo, files):
         match = POM_MODEL_RE.search(content)
         if match:
             return match.group(1)
+
+    # Root pom unreadable; preserve the weaker signal-based knowledge.
+    if 'pom' in files:
+        return '4.1.0'
     return ''
 
 
@@ -701,7 +715,9 @@ def collect_adoption_data(exclude_forks=False, use_snapshot=False):
         # Both may report different versions — keep all of them visible.
         runtime_versions = []
         if 'wrapper' in data['files']:
-            v = extract_version_from_wrapper(owner, repo_name)
+            v = extract_version_from_wrapper(
+                owner, repo_name, data['files']['wrapper']
+            )
             if v:
                 runtime_versions.append(v)
         if 'action' in data['files']:

--- a/scripts/registry_build_status.py
+++ b/scripts/registry_build_status.py
@@ -14,9 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""Re-examine the Last Build status for each alive repo in the registry.
+"""Build-status stage of the Maven 4 adoption registry pipeline.
 
-This is the build-status step of the registry re-examination (Job B).
 "Last Build" means: the most recent COMPLETED run, on the DEFAULT BRANCH,
 of a workflow whose file actually invokes Maven (mvn/mvnw or setup-java).
 
@@ -26,43 +25,37 @@ dynamic "maven in /." update runs match "maven" without being a build.
 Dynamic workflows (path dynamic/...) have no file and are skipped, which
 excludes Dependabot updaters automatically.
 
-Usage: registry_build_status.py <registry.json> [<registry.json out>]
-"""
-import json, re, subprocess, sys
-from concurrent.futures import ThreadPoolExecutor
-from collections import Counter
-from pathlib import Path
+Several Maven workflows with differing decisive results -> AMBIGUOUS,
+linking to the repo's Actions view (we cannot tell which workflow is the
+Maven-4-relevant one). CANCELLED/SKIPPED runs neither confirm nor
+contradict a result, so they do not break agreement.
 
-IN = Path(sys.argv[1])
-OUT = Path(sys.argv[2]) if len(sys.argv) > 2 else IN
+--max-checks N staggers work for the frequent incremental job (Job B):
+only the N stalest entries (by build_checked) are refreshed per run.
+
+Usage: registry_build_status.py <registry.json> [--max-checks N]
+"""
+import argparse
+import sys
+import re
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+
+from registry_lib import gh, load_registry, save_registry, now_iso
+
 # A workflow is a Maven workflow if its file invokes mvn/mvnw or sets up Java.
 MAVEN_CMD = re.compile(r'\bmvnw?\b|actions/setup-java', re.I)
-MAX_WORKFLOWS = 10  # probe at most this many workflow files per repo
-
-
-def gh(endpoint, raw=False):
-    cmd = ['gh', 'api', endpoint]
-    if raw:
-        cmd += ['-H', 'Accept: application/vnd.github.raw']
-    for attempt in range(4):
-        try:
-            r = subprocess.run(cmd, capture_output=True, text=True, check=True)
-            return 'ok', (r.stdout if raw else json.loads(r.stdout))
-        except subprocess.CalledProcessError as e:
-            err = e.stderr or ''
-            if '404' in err:
-                return '404', None
-            if '403' in err or '429' in err or 'rate limit' in err.lower():
-                import time; time.sleep(15 * (attempt + 1)); continue
-            return 'error', None
-        except json.JSONDecodeError:
-            return 'error', None
-    return 'error', None
+MAX_WORKFLOWS = 10   # probe at most this many workflow files per repo
+DECISIVE = {'SUCCESS', 'FAILURE', 'STARTUP_FAILURE', 'TIMED_OUT',
+            'ACTION_REQUIRED'}
 
 
 def build_status(f):
-    f['build'] = 'NONE'; f['build_url'] = ''; f.pop('build_workflow', None)
-    if f['state'] == 'gone':
+    f['build'] = 'NONE'
+    f['build_url'] = ''
+    f.pop('build_workflow', None)
+    f['build_checked'] = now_iso()
+    if f.get('state') == 'gone':
         f['build'] = 'none'
         return f
     full = f.get('current_full_name') or f['repo']
@@ -96,11 +89,11 @@ def build_status(f):
     if not latest:
         return f
 
-    # Only decisive outcomes determine (dis)agreement — a CANCELLED or
-    # SKIPPED run neither confirms nor contradicts a green build.
-    DECISIVE = {'SUCCESS', 'FAILURE', 'STARTUP_FAILURE', 'TIMED_OUT', 'ACTION_REQUIRED'}
     def concl(r):
         return (r.get('conclusion') or 'UNKNOWN').upper()
+
+    # Only decisive outcomes determine (dis)agreement — a CANCELLED or
+    # SKIPPED run neither confirms nor contradicts a green build.
     decisive = [r for r in latest if concl(r) in DECISIVE]
     pool = decisive or latest
     conclusions = {concl(r) for r in pool}
@@ -121,23 +114,41 @@ def build_status(f):
         f['build_url'] = f"https://github.com/{full}/actions"
         counts = Counter(concl(r) for r in latest)
         f['build_workflow'] = (f"{len(latest)} Maven workflows: "
-                               + ", ".join(f"{v} {k}" for k, v in counts.most_common()))
+                               + ", ".join(f"{v} {k}"
+                                           for k, v in counts.most_common()))
     return f
 
 
-data = json.loads(IN.read_text())
-alive = [f for f in data if f['state'] != 'gone']
-print(f"Build status for {len(alive)} alive repos "
-      f"(Maven-invoking workflows, default branch, completed)...", file=sys.stderr)
-with ThreadPoolExecutor(max_workers=8) as ex:
-    for i, _ in enumerate(ex.map(build_status, alive), 1):
-        if i % 50 == 0:
-            print(f"  {i}/{len(alive)}", file=sys.stderr)
-for f in data:
-    f.setdefault('build', 'none'); f.setdefault('build_url', '')
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('registry')
+    ap.add_argument('--max-checks', type=int, default=0,
+                    help='refresh only the N stalest entries (0 = all)')
+    args = ap.parse_args()
 
-OUT.write_text(json.dumps(data, indent=1))
-confirmed = [f for f in data if f.get('live_signal')]
-print("\n=== Last Build among confirmed adopters (Maven workflows only) ===")
-for k, v in Counter(f['build'] for f in confirmed).most_common():
-    print(f"  {v:4d}  {k}")
+    reg = load_registry(args.registry)
+    entries = reg['repos']
+    todo = [e for e in entries if e.get('state') != 'gone']
+    todo.sort(key=lambda e: e.get('build_checked') or '')
+    if args.max_checks > 0:
+        todo = todo[:args.max_checks]
+    print(f"Build status for {len(todo)} of {len(entries)} entries "
+          f"(Maven-invoking workflows, default branch, completed)...",
+          file=sys.stderr)
+    with ThreadPoolExecutor(max_workers=8) as ex:
+        for i, _ in enumerate(ex.map(build_status, todo), 1):
+            if i % 50 == 0:
+                print(f"  {i}/{len(todo)}", file=sys.stderr)
+    for e in entries:
+        e.setdefault('build', 'none')
+        e.setdefault('build_url', '')
+
+    save_registry(args.registry, reg)
+    confirmed = [e for e in entries if e.get('live_signal')]
+    print("\n=== Last Build among confirmed adopters ===")
+    for k, v in Counter(e['build'] for e in confirmed).most_common():
+        print(f"  {v:4d}  {k}")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/registry_build_status.py
+++ b/scripts/registry_build_status.py
@@ -56,12 +56,12 @@ def build_status(f):
     f.pop('build_workflow', None)
     f['build_checked'] = now_iso()
     if f.get('state') == 'gone':
-        f['build'] = 'none'
+        f['build'] = 'NONE'
         return f
     full = f.get('current_full_name') or f['repo']
     st, meta = gh(f"repos/{full}")
     if st != 'ok':
-        f['build'] = 'none'
+        f['build'] = 'NONE'
         return f
     branch = meta.get('default_branch', 'main')
 
@@ -140,7 +140,7 @@ def main():
             if i % 50 == 0:
                 print(f"  {i}/{len(todo)}", file=sys.stderr)
     for e in entries:
-        e.setdefault('build', 'none')
+        e.setdefault('build', 'NONE')
         e.setdefault('build_url', '')
 
     save_registry(args.registry, reg)

--- a/scripts/registry_build_status.py
+++ b/scripts/registry_build_status.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 The Apache Software Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Re-examine the Last Build status for each alive repo in the registry.
+
+This is the build-status step of the registry re-examination (Job B).
+"Last Build" means: the most recent COMPLETED run, on the DEFAULT BRANCH,
+of a workflow whose file actually invokes Maven (mvn/mvnw or setup-java).
+
+Why content-based: name matching is wrong in both directions — real Maven
+builds are often named just "CI"/"build" (false NONE), while Dependabot's
+dynamic "maven in /." update runs match "maven" without being a build.
+Dynamic workflows (path dynamic/...) have no file and are skipped, which
+excludes Dependabot updaters automatically.
+
+Usage: registry_build_status.py <registry.json> [<registry.json out>]
+"""
+import json, re, subprocess, sys
+from concurrent.futures import ThreadPoolExecutor
+from collections import Counter
+from pathlib import Path
+
+IN = Path(sys.argv[1])
+OUT = Path(sys.argv[2]) if len(sys.argv) > 2 else IN
+# A workflow is a Maven workflow if its file invokes mvn/mvnw or sets up Java.
+MAVEN_CMD = re.compile(r'\bmvnw?\b|actions/setup-java', re.I)
+MAX_WORKFLOWS = 10  # probe at most this many workflow files per repo
+
+
+def gh(endpoint, raw=False):
+    cmd = ['gh', 'api', endpoint]
+    if raw:
+        cmd += ['-H', 'Accept: application/vnd.github.raw']
+    for attempt in range(4):
+        try:
+            r = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            return 'ok', (r.stdout if raw else json.loads(r.stdout))
+        except subprocess.CalledProcessError as e:
+            err = e.stderr or ''
+            if '404' in err:
+                return '404', None
+            if '403' in err or '429' in err or 'rate limit' in err.lower():
+                import time; time.sleep(15 * (attempt + 1)); continue
+            return 'error', None
+        except json.JSONDecodeError:
+            return 'error', None
+    return 'error', None
+
+
+def build_status(f):
+    f['build'] = 'NONE'; f['build_url'] = ''; f.pop('build_workflow', None)
+    if f['state'] == 'gone':
+        f['build'] = 'none'
+        return f
+    full = f.get('current_full_name') or f['repo']
+    st, meta = gh(f"repos/{full}")
+    if st != 'ok':
+        f['build'] = 'none'
+        return f
+    branch = meta.get('default_branch', 'main')
+
+    st, wfs = gh(f"repos/{full}/actions/workflows?per_page=50")
+    if st != 'ok' or not wfs.get('workflows'):
+        return f
+    maven_wfs = []
+    for wf in wfs['workflows'][:MAX_WORKFLOWS]:
+        path = wf.get('path', '')
+        # dynamic/... workflows (Dependabot updates, pages) have no file
+        if not path.startswith('.github/workflows/'):
+            continue
+        s, content = gh(f"repos/{full}/contents/{path}", raw=True)
+        if s == 'ok' and content and MAVEN_CMD.search(content):
+            maven_wfs.append(wf)
+
+    # latest completed default-branch run per Maven workflow
+    latest = []
+    for wf in maven_wfs:
+        s, runs = gh(f"repos/{full}/actions/workflows/{wf['id']}/runs"
+                     f"?branch={branch}&status=completed&per_page=1")
+        if s != 'ok' or not runs.get('workflow_runs'):
+            continue
+        latest.append(runs['workflow_runs'][0])
+    if not latest:
+        return f
+
+    # Only decisive outcomes determine (dis)agreement — a CANCELLED or
+    # SKIPPED run neither confirms nor contradicts a green build.
+    DECISIVE = {'SUCCESS', 'FAILURE', 'STARTUP_FAILURE', 'TIMED_OUT', 'ACTION_REQUIRED'}
+    def concl(r):
+        return (r.get('conclusion') or 'UNKNOWN').upper()
+    decisive = [r for r in latest if concl(r) in DECISIVE]
+    pool = decisive or latest
+    conclusions = {concl(r) for r in pool}
+    if len(conclusions) == 1:
+        # one Maven workflow, or several that agree — the statement holds
+        # whichever of them is the M4-relevant one.
+        best = max(pool, key=lambda r: r.get('created_at', ''))
+        f['build'] = conclusions.pop()
+        f['build_url'] = best.get('html_url', '')
+        f['build_workflow'] = best.get('name', '')
+        if len(pool) > 1:
+            f['build_workflow'] = f"{len(pool)} Maven workflows, all agree"
+    else:
+        # several Maven workflows with differing decisive results — we
+        # cannot tell which one is the Maven-4-relevant build. Say so and
+        # link to the repo's Actions view instead of guessing.
+        f['build'] = 'AMBIGUOUS'
+        f['build_url'] = f"https://github.com/{full}/actions"
+        counts = Counter(concl(r) for r in latest)
+        f['build_workflow'] = (f"{len(latest)} Maven workflows: "
+                               + ", ".join(f"{v} {k}" for k, v in counts.most_common()))
+    return f
+
+
+data = json.loads(IN.read_text())
+alive = [f for f in data if f['state'] != 'gone']
+print(f"Build status for {len(alive)} alive repos "
+      f"(Maven-invoking workflows, default branch, completed)...", file=sys.stderr)
+with ThreadPoolExecutor(max_workers=8) as ex:
+    for i, _ in enumerate(ex.map(build_status, alive), 1):
+        if i % 50 == 0:
+            print(f"  {i}/{len(alive)}", file=sys.stderr)
+for f in data:
+    f.setdefault('build', 'none'); f.setdefault('build_url', '')
+
+OUT.write_text(json.dumps(data, indent=1))
+confirmed = [f for f in data if f.get('live_signal')]
+print("\n=== Last Build among confirmed adopters (Maven workflows only) ===")
+for k, v in Counter(f['build'] for f in confirmed).most_common():
+    print(f"  {v:4d}  {k}")

--- a/scripts/registry_discover.py
+++ b/scripts/registry_discover.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 The Apache Software Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Discovery stage of the Maven 4 adoption registry pipeline.
+
+Runs the three Maven 4 code searches and folds the found repos into the
+registry: known repos get their last_seen refreshed, unknown repos are
+added (first_seen = today) for the re-examination stage to fill in.
+
+Two modes:
+  incremental  (Job B, frequent): sort=indexed&order=desc so newly indexed
+      matches come first; stop paginating a query once 2 consecutive pages
+      brought no unknown repo. Cheap — the registry does the counting, the
+      search only has to spot NEW adopters.
+  full         (Job A, daily): paginate every query to the end (with the
+      escalating rate-limit retry). Catches whatever the early-stop missed
+      and records the reconciliation delta that the report annotates.
+
+Usage: registry_discover.py <registry.json> --mode incremental|full
+"""
+import argparse
+import sys
+import time
+
+from registry_lib import (gh, load_registry, save_registry, by_name, today,
+                          load_excluded, is_excluded)
+
+QUERIES = [
+    ('POM 4.1.0', '"maven.apache.org/POM/4.1.0" filename:pom.xml'),
+    ('Wrapper', 'filename:maven-wrapper.properties "apache-maven-4"'),
+    ('GH Action', 'path:.github/workflows "apache-maven-4"'),
+]
+PAGE_DELAY = 7      # code search allows ~10 requests/minute
+MAX_PAGES = 10      # search API serves at most 1000 results
+DRY_PAGES_STOP = 2  # incremental: stop after N consecutive pages w/o news
+
+
+def search_pages(query, label, mode, known, excluded=frozenset()):
+    """Yield repo full_names found for one query. Returns set of names."""
+    found = set()
+    dry = 0
+    params_base = {'q': query, 'per_page': '100'}
+    if mode == 'incremental':
+        params_base.update({'sort': 'indexed', 'order': 'desc'})
+    for page in range(1, MAX_PAGES + 1):
+        print(f"  Searching '{label}' page {page}...", file=sys.stderr)
+        st, data = gh('search/code', params={**params_base, 'page': str(page)})
+        if st != 'ok' or not isinstance(data, dict) or 'items' not in data:
+            print(f"  WARNING: '{label}' page {page} failed ({data}); "
+                  f"stopping this query.", file=sys.stderr)
+            break
+        total = data.get('total_count', 0)
+        if page == 1:
+            print(f"  Total matches: {total}", file=sys.stderr)
+            if total > MAX_PAGES * 100:
+                print(f"  WARNING: {total} matches exceed the search API's "
+                      f"1000-result window; full coverage relies on the "
+                      f"registry, not this single sweep.", file=sys.stderr)
+        items = data['items']
+        page_names = {i.get('repository', {}).get('full_name', '')
+                      for i in items} - {''}
+        new_here = {n for n in page_names
+                    if n.lower() not in known and not is_excluded(n, excluded)}
+        found |= page_names
+        if mode == 'incremental':
+            dry = dry + 1 if not new_here else 0
+            if dry >= DRY_PAGES_STOP:
+                print(f"  '{label}': {dry} pages without news — early stop.",
+                      file=sys.stderr)
+                break
+        if len(items) < 100:
+            break
+        time.sleep(PAGE_DELAY)
+    return found
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('registry')
+    ap.add_argument('--mode', choices=['incremental', 'full'],
+                    default='incremental')
+    args = ap.parse_args()
+
+    reg = load_registry(args.registry)
+    known = by_name(reg)
+    excluded = load_excluded()
+    print(f"Registry: {len(reg['repos'])} tracked repos. "
+          f"Discovery mode: {args.mode}. "
+          f"{len(excluded)} Maven component repos excluded.", file=sys.stderr)
+
+    found_all = set()
+    for label, query in QUERIES:
+        found_all |= search_pages(query, label, args.mode, known, excluded)
+        time.sleep(PAGE_DELAY)
+
+    # Maven's own components are tooling, not adopters
+    dropped = {n for n in found_all if is_excluded(n, excluded)}
+    if dropped:
+        print(f"Excluded {len(dropped)} Maven component repos: "
+              f"{', '.join(sorted(dropped))}", file=sys.stderr)
+    found_all -= dropped
+
+    new_names = sorted(n for n in found_all if n.lower() not in known)
+    for name in new_names:
+        reg['repos'].append({
+            'repo': name,
+            'state': 'active',       # provisional; re-examination confirms
+            'first_seen': today(),
+            'last_seen': today(),
+        })
+    for name in found_all:
+        entry = known.get(name.lower())
+        if entry is not None:
+            entry['last_seen'] = today()
+
+    if args.mode == 'full':
+        reg['reconciliation'] = {
+            'date': today(),
+            'missed': len(new_names),
+            'found_total': len(found_all),
+        }
+
+    save_registry(args.registry, reg)
+    print(f"\nDiscovery: {len(found_all)} repos found, "
+          f"{len(new_names)} new -> registry now {len(reg['repos'])}",
+          file=sys.stderr)
+    if new_names:
+        for n in new_names[:20]:
+            print(f"  NEW {n}", file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/registry_history.py
+++ b/scripts/registry_history.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 The Apache Software Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Append today's registry-derived counts to the adoption time series.
+
+Replaces the old search-sampling data points: the metric is now "repos in
+the registry with a confirmed live Maven 4 signal", which is immune to the
+code-search rate-limit weather that corrupted earlier samples. At most one
+point per day — a rerun on the same date replaces that day's point.
+
+Usage: registry_history.py <registry.json> <history.json>
+"""
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+from registry_lib import load_registry, today
+
+FORGE_NAME = 'github'
+
+
+def main():
+    reg = load_registry(sys.argv[1])
+    hist_path = Path(sys.argv[2])
+    history = json.loads(hist_path.read_text()) if hist_path.exists() else []
+
+    repos = reg['repos']
+    confirmed = [r for r in repos if r.get('live_signal')]
+    signals = dict(Counter(r['live_signal'] for r in confirmed))
+    versions = dict(Counter(r['live_version'] for r in confirmed
+                            if r.get('live_version')))
+    runtimes = {k: v for k, v in versions.items() if '(POM model)' not in k}
+    pom_models = {'4.1.0': versions.get('4.1.0 (POM model)', 0)}
+
+    forge = {
+        'total': len(confirmed),
+        'signals': signals,
+        'pom_models': pom_models,
+        'runtimes': runtimes,
+        'versions': versions,
+        # registry lifecycle context so the honest denominator is recorded
+        'registry': {
+            'tracked': len(repos),
+            'active': sum(1 for r in repos if r.get('state') == 'active'),
+            'archived': sum(1 for r in repos if r.get('state') == 'archived'),
+            'gone': sum(1 for r in repos if r.get('state') == 'gone'),
+        },
+    }
+    point = {
+        'date': today(),
+        'by_forge': {FORGE_NAME: forge},
+        # mirrored top-level aggregates (existing schema convention)
+        'total': forge['total'],
+        'signals': signals,
+        'pom_models': pom_models,
+        'runtimes': runtimes,
+        'versions': versions,
+    }
+
+    history = [p for p in history if p.get('date') != point['date']]
+    history.append(point)
+    history.sort(key=lambda p: p.get('date') or '')
+    hist_path.write_text(json.dumps(history, indent=1))
+    print(f"History: {len(history)} points, today = {forge['total']} "
+          f"confirmed adopters ({len(repos)} tracked)", file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/registry_lib.py
+++ b/scripts/registry_lib.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 The Apache Software Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Shared helpers for the Maven 4 adoption registry pipeline.
+
+The registry is the durable list of every repo ever seen with a Maven 4
+signal. Pipeline stages (discover -> re-examine -> build status -> history
+-> render) all read and write the same registry file.
+
+Registry format (schema 1):
+    {
+      "schema_version": 1,
+      "updated": "<iso>",
+      "reconciliation": {"date": ..., "missed": N, "found_total": M} | null,
+      "repos": [ {repo, state, first_seen, last_seen, last_checked,
+                  gone_since, stars, pushed_at, live_signal, live_version,
+                  source, build, build_url, ...}, ... ]
+    }
+A bare JSON list (the pre-pipeline seed) is accepted and wrapped on load.
+"""
+import json
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+REGISTRY_SCHEMA_VERSION = 1
+
+VER_RE = re.compile(r'apache-maven-(4[\w.\-]+)')
+POM_RE = re.compile(r'maven\.apache\.org/POM/(\d+\.\d+\.\d+)')
+
+
+def today():
+    return datetime.now(timezone.utc).strftime('%Y-%m-%d')
+
+
+def now_iso():
+    return datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+
+def clean_version(v):
+    v = re.sub(r'-bin(\.zip|\.tar\.gz)?$', '', v)
+    v = re.sub(r'\.(zip|tar\.gz)$', '', v)
+    return v
+
+
+def _rate_limit_guard(min_remaining=50):
+    """If the core rate limit is nearly exhausted, sleep until it resets.
+    Keeps long re-examination runs alive under GITHUB_TOKEN's 1000/h cap
+    instead of failing half-way through."""
+    try:
+        r = subprocess.run(['gh', 'api', 'rate_limit'],
+                           capture_output=True, text=True, check=True)
+        core = json.loads(r.stdout)['resources']['core']
+        if core['remaining'] < min_remaining:
+            wait = max(30, core['reset'] - int(time.time()) + 10)
+            print(f"  Core rate limit nearly exhausted "
+                  f"({core['remaining']} left); sleeping {wait}s until reset...",
+                  file=sys.stderr)
+            time.sleep(wait)
+    except Exception:
+        pass  # guard is best-effort
+
+
+_guard_counter = 0
+
+
+def gh(endpoint, raw=False, method='GET', params=None):
+    """GitHub API via gh CLI. Returns (status, payload) with status one of
+    'ok' | '404' | 'error'. Retries rate limits with escalating backoff and
+    consults the core-limit guard every 25 calls."""
+    global _guard_counter
+    _guard_counter += 1
+    if _guard_counter % 25 == 0:
+        _rate_limit_guard()
+
+    cmd = ['gh', 'api', '-X', method, endpoint]
+    if raw:
+        cmd += ['-H', 'Accept: application/vnd.github.raw']
+    if params:
+        for k, v in params.items():
+            cmd += ['-f', f'{k}={v}']
+    for attempt in range(4):
+        try:
+            r = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            return 'ok', (r.stdout if raw else json.loads(r.stdout))
+        except subprocess.CalledProcessError as e:
+            err = e.stderr or ''
+            if '404' in err:
+                return '404', None
+            if '403' in err or '429' in err or 'rate limit' in err.lower():
+                if attempt == 3:
+                    break
+                wait = 30 + 60 * (attempt + 1)
+                print(f"  Rate limited on {endpoint}, waiting {wait}s "
+                      f"(attempt {attempt + 1}/3)...", file=sys.stderr)
+                time.sleep(wait)
+                continue
+            return 'error', err.strip()[:120]
+        except json.JSONDecodeError:
+            return 'error', 'jsondecode'
+    return 'error', 'rate-limit-giveup'
+
+
+def load_registry(path):
+    """Load the registry, wrapping a legacy bare list into schema 1."""
+    path = Path(path)
+    if not path.exists():
+        return {'schema_version': REGISTRY_SCHEMA_VERSION, 'updated': None,
+                'reconciliation': None, 'repos': []}
+    data = json.loads(path.read_text())
+    if isinstance(data, list):
+        return {'schema_version': REGISTRY_SCHEMA_VERSION, 'updated': None,
+                'reconciliation': None, 'repos': data}
+    return data
+
+
+def save_registry(path, reg):
+    reg['schema_version'] = REGISTRY_SCHEMA_VERSION
+    reg['updated'] = now_iso()
+    Path(path).write_text(json.dumps(reg, indent=1))
+
+
+def by_name(reg):
+    """Index repos by (lower-cased) name."""
+    return {r['repo'].lower(): r for r in reg['repos']}
+
+
+def load_excluded(yaml_path=None):
+    """Known Maven component repo names from .gh-configuration.yaml.
+    These are Maven's own components — tooling, not adopters."""
+    if yaml_path is None:
+        yaml_path = Path(__file__).resolve().parent.parent / '.gh-configuration.yaml'
+    yaml_path = Path(yaml_path)
+    if not yaml_path.exists():
+        print(f"Warning: {yaml_path} not found, no exclusions applied.",
+              file=sys.stderr)
+        return set()
+    repos = set()
+    for line in yaml_path.read_text().splitlines():
+        line = line.strip()
+        if line.startswith('- '):
+            name = line[2:].strip()
+            if name and not name.startswith('#'):
+                repos.add(name)
+    return repos
+
+
+def is_excluded(full_name, excluded):
+    """True for Maven's own component repos (apache org only)."""
+    owner, _, repo = full_name.partition('/')
+    return owner == 'apache' and repo in excluded

--- a/scripts/registry_reexamine.py
+++ b/scripts/registry_reexamine.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 The Apache Software Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Re-examination stage of the Maven 4 adoption registry pipeline.
+
+Live-checks registry entries via the core (Contents) API — NOT the flaky
+code-search API — so the adoption count no longer depends on the search's
+rate-limit weather:
+
+  - repo reachable? -> state active/archived/gone (+ gone_since, rename)
+  - Maven 4 signal: root pom.xml (POM 4.1.0) or root wrapper; if neither,
+    a recursive git-tree walk finds nested wrappers/poms/workflows
+  - Maven runtime version from the signal file
+  - last_checked timestamp per entry
+
+--max-checks N staggers work for the frequent incremental job (Job B):
+only the N stalest entries (by last_checked) are re-examined per run,
+keeping each run inside GITHUB_TOKEN's 1000 requests/hour budget. Job A
+passes 0 (= everything).
+
+Usage: registry_reexamine.py <registry.json> [--max-checks N]
+"""
+import argparse
+import sys
+from concurrent.futures import ThreadPoolExecutor
+
+from registry_lib import (gh, load_registry, save_registry, today, now_iso,
+                          clean_version, VER_RE, POM_RE)
+
+
+def probe_root(full):
+    """Root pom.xml / root wrapper. Returns (signal, version, source)."""
+    st, content = gh(f'repos/{full}/contents/pom.xml', raw=True)
+    if st == 'ok' and content:
+        m = POM_RE.search(content)
+        if m and m.group(1) == '4.1.0':
+            return 'POM 4.1.0', '4.1.0 (POM model)', 'root'
+    st, content = gh(f'repos/{full}/contents/.mvn/wrapper/maven-wrapper.properties',
+                     raw=True)
+    if st == 'ok' and content:
+        m = VER_RE.search(content)
+        if m:
+            return 'Wrapper', clean_version(m.group(1)), 'root'
+    return None, None, None
+
+
+def probe_nested(full, default_branch):
+    """Git-tree walk below the root. Returns (signal, version, source)."""
+    st, tree = gh(f'repos/{full}/git/trees/{default_branch}?recursive=1')
+    if st != 'ok' or 'tree' not in tree:
+        return None, None, None
+    paths = [t['path'] for t in tree['tree'] if t.get('type') == 'blob']
+    wrappers = [p for p in paths if p.endswith('maven-wrapper.properties')][:6]
+    poms = [p for p in paths if p.endswith('pom.xml')][:10]
+    flows = [p for p in paths if p.startswith('.github/workflows/')
+             and p.endswith(('.yml', '.yaml'))][:6]
+    for p in wrappers:
+        s, c = gh(f'repos/{full}/contents/{p}', raw=True)
+        if s == 'ok' and c:
+            m = VER_RE.search(c)
+            if m:
+                return 'Wrapper', clean_version(m.group(1)), f'nested:{p}'
+    for p in poms:
+        s, c = gh(f'repos/{full}/contents/{p}', raw=True)
+        if s == 'ok' and c:
+            m = POM_RE.search(c)
+            if m and m.group(1) == '4.1.0':
+                return 'POM 4.1.0', '4.1.0 (POM model)', f'nested:{p}'
+    for p in flows:
+        s, c = gh(f'repos/{full}/contents/{p}', raw=True)
+        if s == 'ok' and c and 'apache-maven-4' in c:
+            m = VER_RE.search(c)
+            return ('GH Action', clean_version(m.group(1)) if m else '',
+                    f'nested:{p}')
+    return None, None, None
+
+
+def examine(entry):
+    name = entry['repo']
+    st, meta = gh(f'repos/{name}')
+    entry['last_checked'] = now_iso()
+    if st == '404':
+        if entry.get('state') != 'gone':
+            entry['gone_since'] = today()
+        entry['state'] = 'gone'
+        entry['live_signal'] = None
+        entry['live_version'] = None
+        return entry
+    if st != 'ok':
+        return entry  # transient error: keep previous knowledge
+    entry.pop('gone_since', None)
+    full = meta.get('full_name', name)
+    entry['current_full_name'] = full
+    entry['renamed_to'] = full if full.lower() != name.lower() else ''
+    entry['state'] = 'archived' if meta.get('archived') else 'active'
+    entry['stars'] = meta.get('stargazers_count', 0)
+    entry['pushed_at'] = (meta.get('pushed_at') or '')[:10]
+
+    sig, ver, src = probe_root(full)
+    if sig is None:
+        sig, ver, src = probe_nested(full, meta.get('default_branch', 'main'))
+    entry['live_signal'] = sig
+    entry['live_version'] = ver
+    entry['source'] = src
+    if sig:
+        entry['lastknown_signal'] = sig
+        entry['lastknown_version'] = ver
+    return entry
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('registry')
+    ap.add_argument('--max-checks', type=int, default=0,
+                    help='re-examine only the N stalest entries (0 = all)')
+    args = ap.parse_args()
+
+    reg = load_registry(args.registry)
+    entries = reg['repos']
+    todo = sorted(entries, key=lambda e: e.get('last_checked') or '')
+    if args.max_checks > 0:
+        todo = todo[:args.max_checks]
+    print(f"Re-examining {len(todo)} of {len(entries)} entries...",
+          file=sys.stderr)
+
+    with ThreadPoolExecutor(max_workers=8) as ex:
+        for i, _ in enumerate(ex.map(examine, todo), 1):
+            if i % 50 == 0:
+                print(f"  {i}/{len(todo)}", file=sys.stderr)
+
+    save_registry(args.registry, reg)
+    confirmed = sum(1 for e in entries if e.get('live_signal'))
+    gone = sum(1 for e in entries if e.get('state') == 'gone')
+    print(f"\nRegistry: {len(entries)} tracked, {confirmed} confirmed live "
+          f"M4 signal, {gone} gone", file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/render_registry_report.py
+++ b/scripts/render_registry_report.py
@@ -54,7 +54,7 @@ sig_c = Counter(f['_sig'] for f in FINAL)
 run_c = Counter(f['_runtime'] for f in FINAL)
 build_c = Counter(f['_build'] for f in FINAL)
 
-BC = {'SUCCESS':'#2a7','FAILURE':'#c33','STARTUP_FAILURE':'#c33','TIMED_OUT':'#c33',
+BC = {'SUCCESS':'#2a7','FAILURE':'#c33','STARTUP_FAILURE':'#c33','TIMED_OUT':'#c33','AMBIGUOUS':'#a80',
       'ACTION_REQUIRED':'#a80','SKIPPED':'#888','CANCELLED':'#888','IN_PROGRESS':'#39c',
       'QUEUED':'#39c','none':'#bbb','UNKNOWN':'#bbb','NEUTRAL':'#888'}
 SC = {'active':'#2a7','archived':'#a80','gone':'#c33'}
@@ -79,8 +79,9 @@ now = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%d %H:%M UTC'
 rows = []
 for f in sorted(FINAL, key=lambda x: (x.get('live_signal') is None, -int(x.get('stars') or 0))):
     bcol = BC.get(f['_build'], '#888')
-    build_cell = (f"<a href='{esc(f.get('build_url'))}' target=_blank rel=noreferrer style='color:{bcol}'>{esc(f.get('build'))}</a>"
-                  if f.get('build_url') else f"<span style='color:{bcol}'>{esc(f.get('build') or '')}</span>")
+    btitle = f" title=\"{esc(f.get('build_workflow'))}\"" if f.get('build_workflow') else ''
+    build_cell = (f"<a href='{esc(f.get('build_url'))}' target=_blank rel=noreferrer style='color:{bcol}'{btitle}>{esc(f.get('build'))}</a>"
+                  if f.get('build_url') else f"<span style='color:{bcol}'{btitle}>{esc(f.get('build') or '')}</span>")
     src = f.get('source') or ''
     srctag = 'root' if src == 'root' else ('nested' if src.startswith('nested') else '')
     dark = ''
@@ -174,7 +175,7 @@ repos with no locatable signal (likely reverted, or a truncated tree). The stati
  <dt>Maven Runtime</dt><dd>Maven CLI version pinned in the wrapper or workflow (e.g. <code>4.0.0-rc-5</code>); <code>4.1.0 (POM model)</code> for POM-only repos.</dd>
  <dt>Src</dt><dd>Where the signal was found on re-examination: <code>root</code> (root <code>pom.xml</code>/<code>.mvn</code>) or <code>nested</code> (below the repo root, via git-tree walk).</dd>
  <dt>Pushed</dt><dd>Date of the most recent push to the default branch — tells active projects apart from dormant ones. <em>Not a Maven 4 signal.</em></dd>
- <dt>Last Build</dt><dd>Conclusion of the repo's most recent GitHub Actions workflow run (any workflow, not necessarily a Maven build); <code>none</code> = no runs found. <em>Not a Maven 4 signal.</em></dd>
+ <dt>Last Build</dt><dd>Conclusion of the most recent <em>completed</em> run, on the <em>default branch</em>, of a workflow that actually invokes Maven (<code>mvn</code>/<code>mvnw</code> or <code>setup-java</code>). <code>AMBIGUOUS</code> = several Maven workflows disagree and we cannot tell which one is the Maven-4-relevant build — the link goes to the repo's Actions view (hover for the breakdown). <code>NONE</code> = no Maven-invoking workflow with a completed default-branch run. <em>Not a Maven 4 signal.</em></dd>
  <dt>Last-known</dt><dd>For a "signal not found" active repo: the signal/runtime last recorded in the CI artifacts, to aid triage of possible reverts.</dd>
 </dl>
 </details>

--- a/scripts/render_registry_report.py
+++ b/scripts/render_registry_report.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 The Apache Software Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Render the Maven 4 adoption registry (maven4-registry.json) to a static
+HTML report. Reads the re-examination records (state, signal, Maven runtime,
+build) and emits a self-contained page with summary cards, stat tables, a
+collapsible legend and Excel-style checkbox filters.
+
+Usage: render_registry_report.py <registry.json> <output.html>
+"""
+import json, html, sys, datetime
+from collections import Counter
+from pathlib import Path
+
+IN = Path(sys.argv[1] if len(sys.argv) > 1 else "data/maven4-registry.json")
+OUT = Path(sys.argv[2] if len(sys.argv) > 2 else "public/maven4-adoption.html")
+FINAL = json.loads(IN.read_text())
+def esc(x): return html.escape(str(x if x is not None else ''))
+
+for f in FINAL:
+    f['_sig'] = f.get('live_signal') or 'none'
+    f['_runtime'] = f.get('live_version') or 'none'
+    f['_build'] = f.get('build') or 'none'
+
+confirmed = [f for f in FINAL if f.get('live_signal')]
+active_n = sum(1 for f in FINAL if f['state'] == 'active')
+arch = sum(1 for f in FINAL if f['state'] == 'archived')
+gone = sum(1 for f in FINAL if f['state'] == 'gone')
+alive_n = active_n + arch
+dark_n = sum(1 for f in FINAL if f['state'] == 'active' and not f.get('live_signal'))
+
+vers = Counter(f['live_version'] for f in confirmed if f.get('live_version'))
+sigs = Counter(f['live_signal'] for f in confirmed)
+builds = Counter(f['_build'] for f in confirmed)
+GREEN = {'SUCCESS'}; RED = {'FAILURE', 'STARTUP_FAILURE', 'TIMED_OUT'}
+green = sum(v for k, v in builds.items() if k in GREEN)
+red = sum(v for k, v in builds.items() if k in RED)
+
+state_c = Counter(f['state'] for f in FINAL)
+sig_c = Counter(f['_sig'] for f in FINAL)
+run_c = Counter(f['_runtime'] for f in FINAL)
+build_c = Counter(f['_build'] for f in FINAL)
+
+BC = {'SUCCESS':'#2a7','FAILURE':'#c33','STARTUP_FAILURE':'#c33','TIMED_OUT':'#c33',
+      'ACTION_REQUIRED':'#a80','SKIPPED':'#888','CANCELLED':'#888','IN_PROGRESS':'#39c',
+      'QUEUED':'#39c','none':'#bbb','UNKNOWN':'#bbb','NEUTRAL':'#888'}
+SC = {'active':'#2a7','archived':'#a80','gone':'#c33'}
+
+def checks(cls, counter, order=None):
+    items = order or [k for k, _ in counter.most_common()]
+    out = []
+    for k in items:
+        if k not in counter: continue
+        out.append(f"<label><input type=checkbox class='f-{cls}' value=\"{esc(k)}\" onchange=flt()> "
+                   f"{esc(k)} <span class=ct>{counter[k]}</span></label>")
+    return "".join(out)
+
+# adoption_date / last_checked are optional (added by the registry pipeline)
+recon = None
+for f in FINAL:
+    if isinstance(f, dict) and f.get('_recon'):
+        recon = f['_recon']; break
+
+now = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%d %H:%M UTC')
+
+rows = []
+for f in sorted(FINAL, key=lambda x: (x.get('live_signal') is None, -int(x.get('stars') or 0))):
+    bcol = BC.get(f['_build'], '#888')
+    build_cell = (f"<a href='{esc(f.get('build_url'))}' target=_blank rel=noreferrer style='color:{bcol}'>{esc(f.get('build'))}</a>"
+                  if f.get('build_url') else f"<span style='color:{bcol}'>{esc(f.get('build') or '')}</span>")
+    src = f.get('source') or ''
+    srctag = 'root' if src == 'root' else ('nested' if src.startswith('nested') else '')
+    dark = ''
+    if f['state'] == 'active' and not f.get('live_signal'):
+        dark = f"last-known: {esc(f.get('lastknown_signal'))} {esc(f.get('lastknown_version'))}"
+    rows.append(
+        f"<tr data-state=\"{esc(f['state'])}\" data-sig=\"{esc(f['_sig'])}\" "
+        f"data-runtime=\"{esc(f['_runtime'])}\" data-build=\"{esc(f['_build'])}\">"
+        f"<td><a href='https://github.com/{esc(f['repo'])}' target=_blank rel=noreferrer>{esc(f['repo'])}</a>"
+        f"{(' → '+esc(f.get('renamed_to'))) if f.get('renamed_to') else ''}</td>"
+        f"<td><span style='color:{SC.get(f['state'],'#888')}'>●</span> {esc(f['state'])}</td>"
+        f"<td style='text-align:right'>{esc(f.get('stars'))}</td>"
+        f"<td>{esc(f.get('pushed_at'))}</td>"
+        f"<td>{esc(f.get('live_signal') or '')}</td>"
+        f"<td>{esc(f.get('live_version') or '')}</td>"
+        f"<td style='color:#888'>{srctag}</td>"
+        f"<td>{build_cell}</td>"
+        f"<td style='color:#a80;font-size:12px'>{dark}</td></tr>")
+
+def stat_tbl(counter):
+    return "".join(f"<tr><td>{esc(k)}</td><td style='text-align:right'>{v}</td></tr>" for k, v in counter.most_common())
+
+recon_html = ""
+if recon:
+    recon_html = (f"<div class=recon>🔄 Last full reconciliation {esc(recon.get('date'))}: "
+                  f"+{esc(recon.get('missed', 0))} adopters the incremental scan had missed "
+                  f"(investigate if this grows).</div>")
+
+doc = f"""<!doctype html><meta charset=utf-8>
+<title>Maven 4 Adoption — Registry</title>
+<style>
+ body{{font:14px/1.5 system-ui,sans-serif;margin:2rem;color:#1c1c1c;max-width:1180px}}
+ h1{{margin-bottom:.2rem}} .sub{{color:#666;margin-top:0}}
+ .cards{{display:flex;gap:.8rem;flex-wrap:wrap;margin:.3rem 0 1rem}}
+ .card{{border:1px solid #ddd;border-radius:8px;padding:.5rem .9rem;min-width:110px}}
+ .card b{{font-size:1.6rem;display:block}}
+ .grouplbl{{margin:.9rem 0 .1rem;font-weight:600;color:#333}}
+ .eq{{font-weight:400;color:#888;font-size:12px}}
+ .two{{display:flex;gap:2rem;flex-wrap:wrap}}
+ table{{border-collapse:collapse;margin:.5rem 0}} #t{{width:100%}}
+ th,td{{border-bottom:1px solid #eee;padding:4px 8px;text-align:left;vertical-align:top}}
+ #t th{{cursor:pointer;background:#fafafa;position:sticky;top:0}}
+ .note{{background:#eef6ff;border-left:3px solid #3b82c4;padding:.6rem 1rem;border-radius:4px}}
+ .recon{{background:#fff8e6;border-left:3px solid #e0a800;padding:.5rem 1rem;border-radius:4px;margin:.6rem 0}}
+ details{{margin:1rem 0}} summary{{cursor:pointer;font-weight:600}}
+ dl.legend dt{{font-weight:600;margin-top:.5rem}} dl.legend dd{{margin:0 0 .1rem 0;color:#444}}
+ code{{background:#f2f2f2;padding:0 3px;border-radius:3px}}
+ .filters{{display:flex;gap:1.2rem;flex-wrap:wrap;align-items:flex-start;border:1px solid #e3e3e3;border-radius:8px;padding:.7rem 1rem;margin:1rem 0}}
+ .fg{{display:flex;flex-direction:column}} .fg > b{{font-size:12px;color:#555;text-transform:uppercase;letter-spacing:.03em}}
+ .fg .box{{max-height:150px;overflow:auto;display:flex;flex-direction:column;gap:1px;margin-top:3px}}
+ .fg label{{font-size:13px;white-space:nowrap}} .ct{{color:#999;font-size:11px}}
+ .fbar{{display:flex;gap:.6rem;align-items:center;margin-bottom:.4rem}}
+ input[type=search]{{padding:5px 8px;min-width:220px}} button{{padding:4px 10px}}
+</style>
+<h1>Maven 4 Adoption — Registry</h1>
+<p class=sub>Generated {now}</p>
+{recon_html}
+<p class=grouplbl>Registry state <span class=eq>({len(FINAL)} = active + archived + gone)</span></p>
+<div class=cards>
+ <div class=card><b>{len(FINAL)}</b>tracked (union)</div>
+ <div class=card><b style='color:#2a7'>{active_n}</b>active</div>
+ <div class=card><b style='color:#a80'>{arch}</b>archived</div>
+ <div class=card><b style='color:#c33'>{gone}</b>gone</div>
+</div>
+<p class=grouplbl>Maven 4 &amp; CI <span class=eq>(among the {alive_n} reachable)</span></p>
+<div class=cards>
+ <div class=card><b>{len(confirmed)}</b>confirmed M4 signal</div>
+ <div class=card><b style='color:#2a7'>{green}</b>CI green</div>
+ <div class=card><b style='color:#c33'>{red}</b>CI failing</div>
+ <div class=card><b style='color:#bbb'>{dark_n}</b>signal not found</div>
+</div>
+
+<div class=note><b>Method:</b> Maven 4 adopters are <b>discovered</b> via GitHub code search and then
+<b>permanently tracked</b>: every repo ever seen is kept in a candidate registry and <b>re-examined live</b>
+on each run (existence, signal, Maven runtime, build) — instead of depending on a single, rate-limit-flaky
+daily search. Signals below the repo root are resolved via a git-tree walk. This snapshot: {len(FINAL)}
+candidates, of which {alive_n} reachable and {len(confirmed)} with a confirmed signal; {dark_n} active
+repos with no locatable signal (likely reverted, or a truncated tree). The statistics below cover the
+{len(confirmed)} confirmed adopters.</div>
+
+<div class=two>
+ <div><h3>Signals</h3><table><tr><th>Signal</th><th>Count</th></tr>{stat_tbl(sigs)}</table></div>
+ <div><h3>Maven Runtime</h3><table><tr><th>Maven Runtime</th><th>Count</th></tr>{stat_tbl(vers)}</table></div>
+ <div><h3>Last Build</h3><table><tr><th>Last Build</th><th>Count</th></tr>{stat_tbl(builds)}</table></div>
+</div>
+
+<details><summary>Legend</summary>
+<dl class=legend>
+ <dt>State</dt><dd><code>active</code> repo reachable · <code>archived</code> read-only (adoption frozen) · <code>gone</code> deleted/private/inaccessible. <em>Not a Maven 4 signal.</em></dd>
+ <dt>Signal</dt><dd>Which Maven 4 detection signal is present: <code>POM 4.1.0</code> (a <code>pom.xml</code> with the new namespace), <code>Wrapper</code> (a <code>maven-wrapper.properties</code> referencing <code>apache-maven-4</code>), <code>GH Action</code> (a workflow installing Maven 4).</dd>
+ <dt>Maven Runtime</dt><dd>Maven CLI version pinned in the wrapper or workflow (e.g. <code>4.0.0-rc-5</code>); <code>4.1.0 (POM model)</code> for POM-only repos.</dd>
+ <dt>Src</dt><dd>Where the signal was found on re-examination: <code>root</code> (root <code>pom.xml</code>/<code>.mvn</code>) or <code>nested</code> (below the repo root, via git-tree walk).</dd>
+ <dt>Pushed</dt><dd>Date of the most recent push to the default branch — tells active projects apart from dormant ones. <em>Not a Maven 4 signal.</em></dd>
+ <dt>Last Build</dt><dd>Conclusion of the repo's most recent GitHub Actions workflow run (any workflow, not necessarily a Maven build); <code>none</code> = no runs found. <em>Not a Maven 4 signal.</em></dd>
+ <dt>Last-known</dt><dd>For a "signal not found" active repo: the signal/runtime last recorded in the CI artifacts, to aid triage of possible reverts.</dd>
+</dl>
+</details>
+
+<h2>Repositories ({len(FINAL)})</h2>
+<div class=fbar>
+ <input type=search id=q placeholder='search repo…' oninput=flt()>
+ <button onclick=clearf()>clear filters</button>
+ <span id=shown class=sub></span>
+</div>
+<div class=filters>
+ <div class=fg><b>State</b><div class=box>{checks('state', state_c, ['active','archived','gone'])}</div></div>
+ <div class=fg><b>Signal</b><div class=box>{checks('sig', sig_c, ['Wrapper','POM 4.1.0','GH Action','none'])}</div></div>
+ <div class=fg><b>Maven Runtime</b><div class=box>{checks('runtime', run_c)}</div></div>
+ <div class=fg><b>Last Build</b><div class=box>{checks('build', build_c)}</div></div>
+</div>
+<table id=t><thead><tr>
+ <th onclick=srt(0)>Repository</th><th onclick=srt(1)>State</th><th onclick=srt(2)>Stars</th>
+ <th onclick=srt(3)>Pushed</th><th onclick=srt(4)>Signal</th><th onclick=srt(5)>Maven Runtime</th>
+ <th onclick=srt(6)>Src</th><th onclick=srt(7)>Last Build</th><th>Last-known (if dark)</th></tr></thead>
+<tbody>
+{''.join(rows)}
+</tbody></table>
+<script>
+ const tb=document.querySelector('#t tbody');
+ const groups=['state','sig','runtime','build'];
+ function flt(){{
+  const q=document.getElementById('q').value.toLowerCase();
+  const checked={{}};
+  groups.forEach(g=>checked[g]=[...document.querySelectorAll('.f-'+g+':checked')].map(c=>c.value));
+  let n=0;
+  for(const tr of tb.rows){{
+   let ok=(!q||tr.cells[0].textContent.toLowerCase().includes(q));
+   for(const g of groups){{ if(ok&&checked[g].length) ok=checked[g].includes(tr.dataset[g]); }}
+   tr.style.display=ok?'':'none'; if(ok)n++;
+  }}
+  document.getElementById('shown').textContent=n+' / '+tb.rows.length+' shown';
+ }}
+ function clearf(){{document.querySelectorAll('.filters input').forEach(c=>c.checked=false);document.getElementById('q').value='';flt();}}
+ function srt(i){{
+  const rows=[...tb.rows].filter(r=>r.style.display!=='none');const num=(i==2);
+  rows.sort((a,b)=>{{let x=a.cells[i].textContent.trim(),y=b.cells[i].textContent.trim();
+   return num?(+y.replace(/\\D/g,'')||0)-(+x.replace(/\\D/g,'')||0):x.localeCompare(y);}});
+  rows.forEach(r=>tb.appendChild(r));
+ }}
+ flt();
+</script>
+"""
+OUT.parent.mkdir(parents=True, exist_ok=True)
+OUT.write_text(doc)
+print(f"Rendered {len(FINAL)} repos -> {OUT}")

--- a/scripts/render_registry_report.py
+++ b/scripts/render_registry_report.py
@@ -36,7 +36,7 @@ def esc(x): return html.escape(str(x if x is not None else ''))
 for f in FINAL:
     f['_sig'] = f.get('live_signal') or 'none'
     f['_runtime'] = f.get('live_version') or 'none'
-    f['_build'] = f.get('build') or 'none'
+    f['_build'] = (f.get('build') or 'NONE').upper()
 
 confirmed = [f for f in FINAL if f.get('live_signal')]
 active_n = sum(1 for f in FINAL if f['state'] == 'active')
@@ -59,7 +59,7 @@ build_c = Counter(f['_build'] for f in FINAL)
 
 BC = {'SUCCESS':'#2a7','FAILURE':'#c33','STARTUP_FAILURE':'#c33','TIMED_OUT':'#c33','AMBIGUOUS':'#a80',
       'ACTION_REQUIRED':'#a80','SKIPPED':'#888','CANCELLED':'#888','IN_PROGRESS':'#39c',
-      'QUEUED':'#39c','none':'#bbb','UNKNOWN':'#bbb','NEUTRAL':'#888'}
+      'QUEUED':'#39c','NONE':'#bbb','UNKNOWN':'#bbb','NEUTRAL':'#888'}
 SC = {'active':'#2a7','archived':'#a80','gone':'#c33'}
 
 def checks(cls, counter, order=None):
@@ -77,8 +77,8 @@ rows = []
 for f in sorted(FINAL, key=lambda x: (x.get('live_signal') is None, -int(x.get('stars') or 0))):
     bcol = BC.get(f['_build'], '#888')
     btitle = f" title=\"{esc(f.get('build_workflow'))}\"" if f.get('build_workflow') else ''
-    build_cell = (f"<a href='{esc(f.get('build_url'))}' target=_blank rel=noreferrer style='color:{bcol}'{btitle}>{esc(f.get('build'))}</a>"
-                  if f.get('build_url') else f"<span style='color:{bcol}'{btitle}>{esc(f.get('build') or '')}</span>")
+    build_cell = (f"<a href='{esc(f.get('build_url'))}' target=_blank rel=noreferrer style='color:{bcol}'{btitle}>{esc(f['_build'])}</a>"
+                  if f.get('build_url') else f"<span style='color:{bcol}'{btitle}>{esc(f['_build'])}</span>")
     src = f.get('source') or ''
     srctag = 'root' if src == 'root' else ('nested' if src.startswith('nested') else '')
     dark = ''

--- a/scripts/render_registry_report.py
+++ b/scripts/render_registry_report.py
@@ -27,7 +27,10 @@ from pathlib import Path
 
 IN = Path(sys.argv[1] if len(sys.argv) > 1 else "data/maven4-registry.json")
 OUT = Path(sys.argv[2] if len(sys.argv) > 2 else "public/maven4-adoption.html")
-FINAL = json.loads(IN.read_text())
+_raw = json.loads(IN.read_text())
+# schema 1 registry object, or the legacy bare list
+FINAL = _raw['repos'] if isinstance(_raw, dict) else _raw
+recon = _raw.get('reconciliation') if isinstance(_raw, dict) else None
 def esc(x): return html.escape(str(x if x is not None else ''))
 
 for f in FINAL:
@@ -67,12 +70,6 @@ def checks(cls, counter, order=None):
         out.append(f"<label><input type=checkbox class='f-{cls}' value=\"{esc(k)}\" onchange=flt()> "
                    f"{esc(k)} <span class=ct>{counter[k]}</span></label>")
     return "".join(out)
-
-# adoption_date / last_checked are optional (added by the registry pipeline)
-recon = None
-for f in FINAL:
-    if isinstance(f, dict) and f.get('_recon'):
-        recon = f['_recon']; break
 
 now = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%d %H:%M UTC')
 


### PR DESCRIPTION
## Problem

The Maven 4 adoption report silently undercounted by ~6x. The wrapper and GH-Action code searches were rate-limited to empty on nearly every run, so all repos entered via the POM 4.1.0 search only: `signals` collapsed to a constant, `maven_runtime` was always empty, `pom_model` was tautologically `4.1.0`, and the daily time series was intermittently corrupted (10–382 repos depending on the day's throttling). The POM 4.1.0 query meanwhile exceeds the search API's 1000-result window, so a single sweep cannot even see all matches anymore.

## Approach

Adopters are **discovered** via code search but **counted** via a durable registry (`maven4-registry.json` on the data branch): every repo ever seen is kept and re-examined live through the core API (existence, signal incl. nested git-tree walk, Maven runtime, build status). A throttled search now means "no news today", never a collapsed count.

## Commits (reviewable independently)

1. **724d674** Retry search rate limits so all signals fire — escalating backoff instead of one 60s try
2. **d75d7f0** Fix pom_model tautology and non-root wrapper runtime — probe the real root pom; use the discovered wrapper path; bump snapshot schema
3. **cf4dd0c** Publish HTML adoption report rendered from registry — replaces the AsciiDoc report
4. **2103370** Decouple publish jobs from the Maven 4 scan — previews deploy in seconds instead of ~24 min
5. **1828c40** Restrict Last Build to Maven-invoking workflows — content-detected (mvn/mvnw/setup-java); AMBIGUOUS + Actions link when several Maven workflows disagree; CANCELLED/SKIPPED don't break agreement
6. **451f134** Add registry pipeline stages — discover (sort=indexed + early-stop / full sweep + reconciliation), re-examine (stalest-slice staggering, lifecycle fields), history (one point/day), shared lib with core-rate-limit guard
7. **82ef726** Add two-job Maven 4 registry workflow — Job B cron `13 */2` incremental, Job A cron `43 5` full + reconciliation delta, shared concurrency group, data-branch push with retry, dispatches Publish on change
8. **e2291df** Retire the AsciiDoc scan job from the publish pipeline

## Validation

- Wrapper search returns 279 matches (was 0); 8/8 sampled wrapper repos resolve a runtime incl. nested paths
- Registry seeded from the union of 66 retained CI artifacts (428 repos), re-examined live: 402 confirmed adopters vs. the degenerate 63
- All pipeline stages tested individually + Job B simulated 1:1 with the workflow commands; result pushed to the data branch
- Branch Netlify preview renders the HTML report from the registry: https://bugfix-report-search-rate-limit--maven-simple-reports.netlify.app/maven4-adoption

## Post-merge

- Dispatch `registry.yml` once (`mode=incremental`) as CI acceptance; crons take over
- Optional: add a `REGISTRY_TOKEN` secret (classic PAT, public_repo) to lift the API budget from 1000/h to 5000/h
- Later: remove `scripts/export_maven4_adoption.py` (kept for reference), adoption_date backfill from git history

🤖 Generated with [Claude Code](https://claude.com/claude-code)