### PR TITLE
Show and filter Dependabot PR assignees; fix silent 403 stall

### DIFF
--- a/web/README.adoc
+++ b/web/README.adoc
@@ -74,6 +74,14 @@ Revoke the token on GitHub if the browser profile is shared.
 The Netlify functions keep the GitHub App *client secret* server-side; only the short-lived user-to-server access token and refresh token live in the browser.
 ====
 
+Assignee column::
+Shows who a Dependabot PR is assigned to on GitHub, so it is visible at a glance that someone has already looked at it and claimed it.
+Each entry links to the assignee's GitHub profile; unassigned PRs show a dash.
+Multiple assignees are all listed.
+The collapsed repo header additionally carries a `👤 <n>` count of assigned PRs.
++
+The data comes from the `assignees` field of the pull-request list response the dashboard already fetches, so the column costs *no* additional API requests and does not affect the rate-limit budget.
+
 Repo filter::
 A regex input narrows the fetch cycle to a subset of `apache/maven-*` repos.
 The pattern is persisted in `localStorage` and applied immediately: previously fetched repos that no longer match are hidden, newly matching repos are queued for the next fetch.

--- a/web/README.adoc
+++ b/web/README.adoc
@@ -76,11 +76,24 @@ The Netlify functions keep the GitHub App *client secret* server-side; only the 
 
 Assignee column::
 Shows who a Dependabot PR is assigned to on GitHub, so it is visible at a glance that someone has already looked at it and claimed it.
-Each entry links to the assignee's GitHub profile; unassigned PRs show a dash.
+Each entry links to the assignee's GitHub profile; unassigned PRs show a dash, and a `?` marks a PR whose cached entry predates the column (it fills in on the next refresh of that repo).
 Multiple assignees are all listed.
 The collapsed repo header additionally carries a `👤 <n>` count of assigned PRs.
 +
 The data comes from the `assignees` field of the pull-request list response the dashboard already fetches, so the column costs *no* additional API requests and does not affect the rate-limit budget.
++
+[NOTE]
+====
+New PR fields are added *without* breaking the persisted cache.
+`assignees` is declared optional on `DependabotPr`, so entries written by earlier versions stay readable instead of forcing a `gh-result:` version bump — a bump would discard every repo's last known state and burn a full refetch cycle against the rate limit.
+An absent field means "not known yet", which `hasAssigneeData()` keeps distinct from "nobody assigned"; the UI and the filter both honour that distinction rather than claiming a PR is unassigned when the data simply has not been fetched yet.
+====
+
+Assignee filter::
+A dropdown next to _Hide repos without PRs_ narrows the table to *Assigned (anyone)*, *Unassigned*, or one specific assignee (the list is built from whoever appears in the PRs fetched so far).
+While a filter is active, repos without a matching PR are hidden entirely and matching repos are auto-expanded, so selecting a login answers "what is that person sitting on?" in one glance.
+The selection is persisted in `localStorage`.
+Filtering is purely client-side over already fetched data — it costs no API requests, but it can only match repos the current cycle has actually reached.
 
 Repo filter::
 A regex input narrows the fetch cycle to a subset of `apache/maven-*` repos.

--- a/web/src/components/PrTable.tsx
+++ b/web/src/components/PrTable.tsx
@@ -16,9 +16,14 @@
 
 import { useState } from 'react'
 import type { DependabotPr, PrAssignee, RepoFetchResult } from '../lib/types'
-import { assigneesOf } from '../lib/types'
+import { assigneesOf, hasAssigneeData } from '../lib/types'
 import { MAVEN_OWNER } from '../lib/repos'
-import { readHideEmpty, writeHideEmpty } from '../lib/cache'
+import {
+  readAssigneeFilter,
+  readHideEmpty,
+  writeAssigneeFilter,
+  writeHideEmpty,
+} from '../lib/cache'
 import { StatusBadge } from './StatusBadge'
 
 const STALE_THRESHOLD_MS = 60 * 60_000
@@ -80,6 +85,38 @@ function countAssigned(prs: DependabotPr[]): number {
   return prs.filter((pr) => assigneesOf(pr).length > 0).length
 }
 
+/** Sentinel values for the assignee dropdown; anything else is a GitHub login. */
+const ASSIGNEE_ALL = 'all'
+const ASSIGNEE_ANY = '__any__'
+const ASSIGNEE_NONE = '__none__'
+
+function matchesAssignee(pr: DependabotPr, filter: string): boolean {
+  if (filter === ASSIGNEE_ALL) return true
+  // A PR whose entry predates the column is *unknown*, not unassigned — it
+  // must not show up under "Unassigned" and claim nobody has picked it up.
+  if (!hasAssigneeData(pr)) return false
+  const assignees = assigneesOf(pr)
+  if (filter === ASSIGNEE_ANY) return assignees.length > 0
+  if (filter === ASSIGNEE_NONE) return assignees.length === 0
+  return assignees.some((a) => a.login === filter)
+}
+
+function filterPrs(prs: DependabotPr[], assigneeFilter: string): DependabotPr[] {
+  if (assigneeFilter === ASSIGNEE_ALL) return prs
+  return prs.filter((pr) => matchesAssignee(pr, assigneeFilter))
+}
+
+/** Distinct logins across everything fetched so far, for the dropdown. */
+function collectAssignees(results: Record<string, RepoFetchResult>): string[] {
+  const logins = new Set<string>()
+  for (const result of Object.values(results)) {
+    for (const pr of result.prs) {
+      for (const a of assigneesOf(pr)) logins.add(a.login)
+    }
+  }
+  return [...logins].sort((a, b) => a.localeCompare(b))
+}
+
 interface Props {
   allRepos: readonly string[]
   results: Record<string, RepoFetchResult>
@@ -92,9 +129,19 @@ export function PrTable({ allRepos, results, inFlight }: Props) {
   // has at least one PR.
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
   const [hideEmpty, setHideEmpty] = useState<boolean>(() => readHideEmpty())
+  const [assigneeFilter, setAssigneeFilter] = useState<string>(() => readAssigneeFilter())
+
+  const knownAssignees = collectAssignees(results)
+  const filtering = assigneeFilter !== ASSIGNEE_ALL
+
+  const prsFor = (repo: string): DependabotPr[] =>
+    filterPrs(results[repo]?.prs ?? [], assigneeFilter)
 
   const isCollapsed = (repo: string): boolean => {
     if (repo in collapsed) return collapsed[repo]
+    // While filtering, a matching repo is worth showing open — the whole point
+    // of the filter is to see the matches without clicking through 99 repos.
+    if (filtering) return prsFor(repo).length === 0
     const result = results[repo]
     return !result || result.prs.length === 0
   }
@@ -114,18 +161,32 @@ export function PrTable({ allRepos, results, inFlight }: Props) {
     writeHideEmpty(value)
   }
 
-  // Hide only fully-fetched repos with zero PRs. Keep pending and errored
-  // entries visible so the user can still see fetch state.
-  const visible = hideEmpty
-    ? sorted.filter((repo) => {
-        const r = results[repo]
-        if (!r) return true
-        if (r.error) return true
-        return r.prs.length > 0
-      })
-    : sorted
+  const updateAssigneeFilter = (value: string) => {
+    setAssigneeFilter(value)
+    writeAssigneeFilter(value)
+    // Drop manual collapse overrides so the new filter decides what is open.
+    setCollapsed({})
+  }
+
+  // An active assignee filter hides non-matching repos outright — otherwise
+  // the answer to "what is this person working on?" is buried in 90+ headers.
+  // Without it, hide only fully-fetched repos with zero PRs, keeping pending
+  // and errored entries visible so fetch state stays observable.
+  const visible = filtering
+    ? sorted.filter((repo) => prsFor(repo).length > 0)
+    : hideEmpty
+      ? sorted.filter((repo) => {
+          const r = results[repo]
+          if (!r) return true
+          if (r.error) return true
+          return r.prs.length > 0
+        })
+      : sorted
 
   const hiddenCount = sorted.length - visible.length
+  const matchCount = filtering
+    ? visible.reduce((n, repo) => n + prsFor(repo).length, 0)
+    : 0
 
   return (
     <div className="pr-table-wrap">
@@ -134,11 +195,39 @@ export function PrTable({ allRepos, results, inFlight }: Props) {
           <input
             type="checkbox"
             checked={hideEmpty}
+            disabled={filtering}
             onChange={(e) => updateHideEmpty(e.target.checked)}
           />
           Hide repos without PRs
-          {hideEmpty && hiddenCount > 0 && (
+          {!filtering && hideEmpty && hiddenCount > 0 && (
             <span className="muted"> ({hiddenCount} hidden)</span>
+          )}
+        </label>
+        <label className="assignee-filter">
+          Assignee{' '}
+          <select
+            value={assigneeFilter}
+            onChange={(e) => updateAssigneeFilter(e.target.value)}
+          >
+            <option value={ASSIGNEE_ALL}>All</option>
+            <option value={ASSIGNEE_ANY}>Assigned (anyone)</option>
+            <option value={ASSIGNEE_NONE}>Unassigned</option>
+            {knownAssignees.length > 0 && (
+              <optgroup label="Assigned to">
+                {knownAssignees.map((login) => (
+                  <option key={login} value={login}>
+                    {login}
+                  </option>
+                ))}
+              </optgroup>
+            )}
+          </select>
+          {filtering && (
+            <span className="muted">
+              {' '}
+              ({matchCount} PR{matchCount === 1 ? '' : 's'} in {visible.length} repo
+              {visible.length === 1 ? '' : 's'})
+            </span>
           )}
         </label>
         <span className="pr-table-controls-spacer" />
@@ -164,6 +253,7 @@ export function PrTable({ allRepos, results, inFlight }: Props) {
             <RepoRows
               key={repo}
               repo={repo}
+              prs={prsFor(repo)}
               result={results[repo]}
               isInFlight={inFlight === repo}
               collapsed={isCollapsed(repo)}
@@ -178,15 +268,17 @@ export function PrTable({ allRepos, results, inFlight }: Props) {
 
 interface RepoRowsProps {
   repo: string
+  /** Already narrowed by the assignee filter; may be a subset of result.prs. */
+  prs: DependabotPr[]
   result: RepoFetchResult | undefined
   isInFlight: boolean
   collapsed: boolean
   onToggle: () => void
 }
 
-function RepoRows({ repo, result, isInFlight, collapsed, onToggle }: RepoRowsProps) {
+function RepoRows({ repo, prs: input, result, isInFlight, collapsed, onToggle }: RepoRowsProps) {
   const repoUrl = `https://github.com/${MAVEN_OWNER}/${repo}/pulls`
-  const prs = result ? [...result.prs].sort((a, b) => b.createdAt.localeCompare(a.createdAt)) : []
+  const prs = [...input].sort((a, b) => b.createdAt.localeCompare(a.createdAt))
   const counts = countBuildStates(prs)
   const empty = prs.length === 0
   const className = `repo-header${empty ? ' repo-header-empty' : ''}${
@@ -291,7 +383,18 @@ function avatarSrc(url: string): string {
   return `${url}${url.includes('?') ? '&' : '?'}s=${AVATAR_PX * 2}`
 }
 
-function AssigneeCell({ assignees }: { assignees: PrAssignee[] }) {
+function AssigneeCell({ pr }: { pr: DependabotPr }) {
+  if (!hasAssigneeData(pr)) {
+    return (
+      <span
+        className="muted"
+        title="Not known yet — this entry was cached before the column existed. It fills in on the next refresh of this repo."
+      >
+        ?
+      </span>
+    )
+  }
+  const assignees: PrAssignee[] = assigneesOf(pr)
   if (assignees.length === 0) {
     return (
       <span className="muted" title="Nobody has claimed this PR yet">
@@ -335,7 +438,7 @@ function PrRow({ pr }: { pr: DependabotPr }) {
       </td>
       <td className="nowrap">{formatPrDate(pr.createdAt)}</td>
       <td className="nowrap">
-        <AssigneeCell assignees={assigneesOf(pr)} />
+        <AssigneeCell pr={pr} />
       </td>
       <td>
         <a href={pr.checksUrl} target="_blank" rel="noreferrer">

--- a/web/src/components/PrTable.tsx
+++ b/web/src/components/PrTable.tsx
@@ -15,7 +15,8 @@
  */
 
 import { useState } from 'react'
-import type { DependabotPr, RepoFetchResult } from '../lib/types'
+import type { DependabotPr, PrAssignee, RepoFetchResult } from '../lib/types'
+import { assigneesOf } from '../lib/types'
 import { MAVEN_OWNER } from '../lib/repos'
 import { readHideEmpty, writeHideEmpty } from '../lib/cache'
 import { StatusBadge } from './StatusBadge'
@@ -73,6 +74,10 @@ function countBuildStates(prs: DependabotPr[]): BuildCounts {
     }
   }
   return c
+}
+
+function countAssigned(prs: DependabotPr[]): number {
+  return prs.filter((pr) => assigneesOf(pr).length > 0).length
 }
 
 interface Props {
@@ -149,6 +154,7 @@ export function PrTable({ allRepos, results, inFlight }: Props) {
           <tr>
             <th>Title</th>
             <th>Date</th>
+            <th>Assignee</th>
             <th>Build status</th>
             <th>PR</th>
           </tr>
@@ -191,7 +197,7 @@ function RepoRows({ repo, result, isInFlight, collapsed, onToggle }: RepoRowsPro
   return (
     <>
       <tr className={className}>
-        <td colSpan={4}>
+        <td colSpan={5}>
           <button
             type="button"
             className="repo-toggle"
@@ -206,7 +212,13 @@ function RepoRows({ repo, result, isInFlight, collapsed, onToggle }: RepoRowsPro
           <a href={repoUrl} target="_blank" rel="noreferrer">
             {repo}
           </a>
-          <RepoMeta result={result} isInFlight={isInFlight} counts={counts} prCount={prs.length} />
+          <RepoMeta
+            result={result}
+            isInFlight={isInFlight}
+            counts={counts}
+            prCount={prs.length}
+            assignedCount={countAssigned(prs)}
+          />
         </td>
       </tr>
       {!collapsed && prs.map((pr) => <PrRow key={pr.number} pr={pr} />)}
@@ -219,9 +231,10 @@ interface RepoMetaProps {
   isInFlight: boolean
   counts: BuildCounts
   prCount: number
+  assignedCount: number
 }
 
-function RepoMeta({ result, isInFlight, counts, prCount }: RepoMetaProps) {
+function RepoMeta({ result, isInFlight, counts, prCount, assignedCount }: RepoMetaProps) {
   if (isInFlight) return <span className="muted"> · fetching…</span>
   if (!result) return <span className="muted"> · pending</span>
   if (result.error) return <span className="muted"> · error: {result.error}</span>
@@ -254,8 +267,61 @@ function RepoMeta({ result, isInFlight, counts, prCount }: RepoMetaProps) {
           · ⏳ {counts.pending}
         </span>
       )}
+      {assignedCount > 0 && (
+        <span
+          className="count count-assigned"
+          title={`${assignedCount} of ${prCount} already assigned`}
+        >
+          {' '}
+          · 👤 {assignedCount}
+        </span>
+      )}
       <span className="muted"> · {fetched}</span>
     </>
+  )
+}
+
+const AVATAR_PX = 18
+
+/**
+ * GitHub avatar URLs already carry a `?v=4` query, so the size hint has to be
+ * appended rather than set. Request 2× for crisp rendering on HiDPI displays.
+ */
+function avatarSrc(url: string): string {
+  return `${url}${url.includes('?') ? '&' : '?'}s=${AVATAR_PX * 2}`
+}
+
+function AssigneeCell({ assignees }: { assignees: PrAssignee[] }) {
+  if (assignees.length === 0) {
+    return (
+      <span className="muted" title="Nobody has claimed this PR yet">
+        —
+      </span>
+    )
+  }
+  return (
+    <span className="assignee-list">
+      {assignees.map((a) => (
+        <a
+          key={a.login}
+          className="assignee"
+          href={a.htmlUrl}
+          target="_blank"
+          rel="noreferrer"
+          title={`Assigned to ${a.login}`}
+        >
+          <img
+            className="assignee-avatar"
+            src={avatarSrc(a.avatarUrl)}
+            alt=""
+            width={AVATAR_PX}
+            height={AVATAR_PX}
+            loading="lazy"
+          />
+          {a.login}
+        </a>
+      ))}
+    </span>
   )
 }
 
@@ -268,6 +334,9 @@ function PrRow({ pr }: { pr: DependabotPr }) {
         {pr.title}
       </td>
       <td className="nowrap">{formatPrDate(pr.createdAt)}</td>
+      <td className="nowrap">
+        <AssigneeCell assignees={assigneesOf(pr)} />
+      </td>
       <td>
         <a href={pr.checksUrl} target="_blank" rel="noreferrer">
           <StatusBadge state={pr.buildState} />

--- a/web/src/lib/cache.ts
+++ b/web/src/lib/cache.ts
@@ -21,6 +21,7 @@ const FILTER_KEY = 'gh-filter:v1'
 const TOKEN_KEY = 'gh-token:v1'
 const TOKEN_PERSIST_KEY = 'gh-token-persist:v1'
 const HIDE_EMPTY_KEY = 'gh-hide-empty:v1'
+const ASSIGNEE_FILTER_KEY = 'gh-assignee-filter:v1'
 const OAUTH_KEY = 'gh-oauth:v1'
 
 const ARCHIVED_TTL_MS = 7 * 24 * 60 * 60_000
@@ -166,6 +167,28 @@ export function writeHideEmpty(hide: boolean): void {
   try {
     if (hide) localStorage.setItem(HIDE_EMPTY_KEY, '1')
     else localStorage.removeItem(HIDE_EMPTY_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Assignee filter: 'all' (no filtering), 'any', 'none', or a GitHub login.
+ * Stored as a plain string; unknown logins simply match nothing until the
+ * next fetch cycle repopulates the option list.
+ */
+export function readAssigneeFilter(): string {
+  try {
+    return localStorage.getItem(ASSIGNEE_FILTER_KEY) ?? 'all'
+  } catch {
+    return 'all'
+  }
+}
+
+export function writeAssigneeFilter(value: string): void {
+  try {
+    if (value && value !== 'all') localStorage.setItem(ASSIGNEE_FILTER_KEY, value)
+    else localStorage.removeItem(ASSIGNEE_FILTER_KEY)
   } catch {
     // ignore
   }

--- a/web/src/lib/dependabot.ts
+++ b/web/src/lib/dependabot.ts
@@ -22,10 +22,16 @@ import {
 } from './buildStatus'
 import { MAVEN_OWNER } from './repos'
 import { readArchived, writeArchived, writeResult } from './cache'
-import type { DependabotPr, RepoFetchResult } from './types'
+import type { DependabotPr, PrAssignee, RepoFetchResult } from './types'
 
 interface RepoMetadata {
   archived: boolean
+}
+
+interface RestUser {
+  login: string
+  avatar_url: string
+  html_url: string
 }
 
 interface RestPullRequest {
@@ -38,6 +44,11 @@ interface RestPullRequest {
   html_url: string
   head: { sha: string }
   base: { ref: string }
+  // Both are part of the list payload already — no extra request needed.
+  // `assignee` is the deprecated single-assignee field; `assignees` supersedes
+  // it and is a superset, so we only fall back when the array is absent.
+  assignees: RestUser[] | null
+  assignee: RestUser | null
 }
 
 const DEPENDABOT_LOGIN_PATTERNS = [/^dependabot(\[bot\])?$/i, /^app\/dependabot$/i]
@@ -45,6 +56,15 @@ const DEPENDABOT_LOGIN_PATTERNS = [/^dependabot(\[bot\])?$/i, /^app\/dependabot$
 function isDependabotAuthor(login: string | undefined | null): boolean {
   if (!login) return false
   return DEPENDABOT_LOGIN_PATTERNS.some((re) => re.test(login))
+}
+
+function toAssignees(pr: RestPullRequest): PrAssignee[] {
+  const raw = pr.assignees ?? (pr.assignee ? [pr.assignee] : [])
+  return raw.map((u) => ({
+    login: u.login,
+    avatarUrl: u.avatar_url,
+    htmlUrl: u.html_url,
+  }))
 }
 
 export interface FetchRepoOptions {
@@ -107,6 +127,7 @@ export async function fetchRepoPrs(repo: string, opts: FetchRepoOptions = {}): P
         headSha: pr.head.sha,
         buildState: 'UNKNOWN',
         buildStateFetchedAt: null,
+        assignees: toAssignees(pr),
       }
 
       if (!opts.skipChecks) {

--- a/web/src/lib/githubFetch.ts
+++ b/web/src/lib/githubFetch.ts
@@ -46,9 +46,15 @@ class SerialQueue {
     return new Promise<T>((resolve, reject) => {
       const item: QueueItem = {
         run: async () => {
-          const wait = this.backoffUntil - Date.now()
-          if (wait > 0) {
-            await sleep(wait)
+          // Re-read the deadline on every slice instead of sleeping it out in
+          // one go: clearBackoff() (a token was added, "Refresh now" pressed)
+          // must take effect immediately. Sleeping the full span would serve
+          // out a backoff of up to an hour that the user has already lifted,
+          // with nothing on screen explaining the wait.
+          for (;;) {
+            const wait = this.backoffUntil - Date.now()
+            if (wait <= 0) break
+            await sleep(Math.min(wait, 500))
           }
           try {
             resolve(await work())
@@ -101,6 +107,32 @@ function parseRateLimit(headers: Headers): RateLimitInfo | null {
   }
 }
 
+/**
+ * Distinguish a genuine quota/abuse throttle from an authorization 403.
+ * 429 is always a throttle; for 403 we trust the rate-limit headers GitHub
+ * sets on quota rejections (`x-ratelimit-remaining: 0`, `retry-after` on
+ * secondary limits) and fall back to the message body. Anything else — most
+ * importantly "Resource not accessible by integration" — is a permission
+ * problem the user needs to see, not something to wait out.
+ */
+function isRateLimited(res: Response, body: string): boolean {
+  if (res.status === 429) return true
+  if (res.headers.get('retry-after')) return true
+  if (res.headers.get('x-ratelimit-remaining') === '0') return true
+  return /rate limit|abuse detection/i.test(body)
+}
+
+/** Pull GitHub's `message` field out of an error body, falling back to raw text. */
+function extractMessage(body: string): string {
+  try {
+    const parsed = JSON.parse(body) as { message?: string }
+    if (parsed.message) return parsed.message
+  } catch {
+    // not JSON — fall through
+  }
+  return body.slice(0, 200) || 'no message'
+}
+
 function computeBackoff(res: Response): number {
   const retryAfter = res.headers.get('retry-after')
   if (retryAfter) {
@@ -150,10 +182,22 @@ export async function ghFetch<T>(path: string, opts: GhFetchOptions = {}): Promi
     }
 
     if (res.status === 403 || res.status === 429) {
-      const until = computeBackoff(res)
-      queue.setBackoff(until)
-      const message = `GitHub API ${res.status} (backoff until ${new Date(until).toLocaleTimeString()})`
-      throw new GhRateLimitError(message, until, res.status)
+      // GitHub overloads 403: quota exhausted *and* plain authorization
+      // failures ("Resource not accessible by integration" when a GitHub App
+      // token hits repos the App isn't installed on). Backing off on the
+      // latter turns a permission problem into a silent multi-minute wait
+      // with no error anywhere — so classify before deciding.
+      const body = await res.text().catch(() => '')
+      if (isRateLimited(res, body)) {
+        const until = computeBackoff(res)
+        queue.setBackoff(until)
+        const message = `GitHub API ${res.status} (backoff until ${new Date(until).toLocaleTimeString()})`
+        throw new GhRateLimitError(message, until, res.status)
+      }
+      throw new GhAccessError(
+        `GitHub API ${res.status}: ${extractMessage(body)}`,
+        res.status,
+      )
     }
 
     if (!res.ok) {
@@ -172,5 +216,17 @@ export class GhRateLimitError extends Error {
   constructor(message: string, public readonly until: number, public readonly status: number) {
     super(message)
     this.name = 'GhRateLimitError'
+  }
+}
+
+/**
+ * A 403 that is *not* a quota rejection: bad or insufficiently scoped
+ * credentials. Deliberately not a GhRateLimitError, so the fetch loop records
+ * it as a per-repo error the user can read instead of pausing on it.
+ */
+export class GhAccessError extends Error {
+  constructor(message: string, public readonly status: number) {
+    super(message)
+    this.name = 'GhAccessError'
   }
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -48,11 +48,25 @@ export interface DependabotPr {
   buildState: BuildState
   buildStateFetchedAt: number | null
   /**
-   * Optional because results persisted by earlier versions predate this field.
-   * Read it via `assigneesOf()` rather than directly, so cached entries degrade
-   * to "unassigned" instead of crashing the render.
+   * Optional on purpose: results persisted by earlier versions predate this
+   * field, and we want them to keep working rather than force a cache version
+   * bump (which would discard every repo's last known state and burn a full
+   * refetch cycle against the rate limit).
+   *
+   * `undefined` therefore means "this cached entry was written before the
+   * column existed" — *not* "nobody is assigned". Use `hasAssigneeData()` to
+   * tell the two apart and `assigneesOf()` to read the list safely.
    */
   assignees?: PrAssignee[]
+}
+
+/**
+ * True once a PR has been fetched by a version that knows about assignees.
+ * Distinguishes a genuinely unassigned PR from a stale cache entry, so the UI
+ * never claims "unassigned" about data it simply does not have yet.
+ */
+export function hasAssigneeData(pr: DependabotPr): boolean {
+  return pr.assignees !== undefined
 }
 
 /** Null-safe accessor tolerating pre-assignee entries from `localStorage`. */

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -27,6 +27,12 @@ export interface RateLimitInfo {
   resetAt: number // ms epoch
 }
 
+export interface PrAssignee {
+  login: string
+  avatarUrl: string
+  htmlUrl: string
+}
+
 export interface DependabotPr {
   repo: string
   number: number
@@ -41,6 +47,17 @@ export interface DependabotPr {
   headSha: string
   buildState: BuildState
   buildStateFetchedAt: number | null
+  /**
+   * Optional because results persisted by earlier versions predate this field.
+   * Read it via `assigneesOf()` rather than directly, so cached entries degrade
+   * to "unassigned" instead of crashing the render.
+   */
+  assignees?: PrAssignee[]
+}
+
+/** Null-safe accessor tolerating pre-assignee entries from `localStorage`. */
+export function assigneesOf(pr: DependabotPr): PrAssignee[] {
+  return pr.assignees ?? []
 }
 
 export interface RepoFetchResult {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -462,6 +462,36 @@ code {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
+.assignee-list {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.assignee {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  text-decoration: none;
+}
+
+.assignee:hover {
+  text-decoration: underline;
+}
+
+.assignee-avatar {
+  flex: 0 0 auto;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: var(--row-alt);
+}
+
+.count-assigned {
+  color: var(--muted);
+}
+
 footer {
   margin-top: 32px;
   font-size: 12px;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -317,6 +317,29 @@ code {
   cursor: pointer;
 }
 
+.pr-table-controls .hide-empty input:disabled,
+.pr-table-controls .hide-empty:has(input:disabled) {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.pr-table-controls .assignee-filter {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  font-size: 12px;
+}
+
+.pr-table-controls .assignee-filter select {
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+  padding: 3px 6px;
+  border-radius: 4px;
+  font: inherit;
+  cursor: pointer;
+}
+
 .pr-table-controls button {
   border: 1px solid var(--border);
   background: var(--bg);


### PR DESCRIPTION
The dashboard showed whether a Dependabot PR builds, but not whether anyone had picked it up. Surfacing the assignee makes it visible at a glance that a PR has already been looked at and claimed, so reviewers do not duplicate each other's work.

**Assignee column** between *Date* and *Build status*: avatar plus login, linked to the GitHub profile, with all assignees listed when there are several. Collapsed repo headers additionally carry a `👤 n` count. The data comes from the `assignees` field of the pull-request list response the dashboard already fetches, so the column costs **no additional API requests**.

**Assignee filter:** a dropdown offering *Assigned (anyone)*, *Unassigned*, or a specific login. While it is active, non-matching repos are hidden and matching ones auto-expand. Purely client-side over data already fetched.

**Cache stays compatible:** `assignees` is optional on `DependabotPr`, so no `gh-result:` version bump — a bump would discard every user's last known state for all repos and burn a full refetch cycle. An absent field means "not known yet", not "nobody assigned"; `hasAssigneeData()` keeps the two apart, such PRs render `?` and are excluded from both filter directions.

**Bug fix (independent of the feature):** GitHub returns 403 both for exhausted quota and for authorization failures. Treating every 403 as a throttle turned a permission problem into a silent wait — no error surfaced and the cycle stalled. Classification now goes through 429 / `retry-after` / `x-ratelimit-remaining`, and anything else raises `GhAccessError` carrying GitHub's own message as a readable per-repo error. The queue backoff is also interruptible now: `clearQueueBackoff()` could not wake a request already sleeping, so adding a token or pressing *Refresh now* had no effect until the original deadline passed.

**Not covered by tests:** the project has no test setup, so only `tsc` and the build were verified. The 403 fix was derived by reading the code, not proven by a test. A small vitest suite for the pure logic is the obvious follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
